### PR TITLE
Setup continuous delivery of college-schedule-app

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -21,9 +21,8 @@
             "labels": ["Task"]
         }
     ],
-    "mode": "ISSUES",
     "template": "${{CHANGELOG}}\n\n## 🔗 Корисні посилання\n- [Інструкція з інсталяції](README.md)\n- [GitHub Releases](https://github.com/${{OWNER}}/${{REPOSITORY}}/releases)",
-    "issue_template": "- ${{TITLE}} (#${{NUMBER}})",
+    "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
     "empty_template": "- Немає змін в цій категорії",
     "sort": "ASC",
     "base_branches": ["main"]

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -1,0 +1,30 @@
+{
+    "categories": [
+        {
+            "title": "## 🚀 Нові функції",
+            "labels": ["Feature Request", "Enhancement"]
+        },
+        {
+            "title": "## 🐛 Виправлення",
+            "labels": ["Bug"]
+        },
+        {
+            "title": "## ⚙️ CI/CD",
+            "labels": ["Continuous Integration", "Continuous Delivery", "Continuous Deployment"]
+        },
+        {
+            "title": "## ✅ Тестування",
+            "labels": ["Chore"]
+        },
+        {
+            "title": "## 🔨 Інші зміни",
+            "labels": ["Task"]
+        }
+    ],
+    "mode": "ISSUES",
+    "template": "${{CHANGELOG}}\n\n## 🔗 Корисні посилання\n- [Інструкція з інсталяції](README.md)\n- [GitHub Releases](https://github.com/${{OWNER}}/${{REPOSITORY}}/releases)",
+    "issue_template": "- ${{TITLE}} (#${{NUMBER}})",
+    "empty_template": "- Немає змін в цій категорії",
+    "sort": "ASC",
+    "base_branches": ["main"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,10 @@ jobs:
           name: build-logs
           path: target/ci-logs/**
           if-no-files-found: warn
+
+  # Stage 3: публікація пакету після успішної збірки.
+  publish:
+    name: Publish Package
+    needs: build
+    uses: ./.github/workflows/maven-publish.yml
+    secrets: inherit

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,74 @@
+# Workflow для публікації пакетів Maven в GitHub Packages
+# GITHUB_ACTOR та GITHUB_TOKEN автоматично надаються GitHub Actions:
+# - GITHUB_ACTOR: ім'я користувача, який запустив workflow
+# - GITHUB_TOKEN: автоматично генерується для кожного запуску workflow
+#   і має необхідні права для публікації пакетів
+name: Maven Package
+
+# Запускається при пушах в гілку main або при створенні pull request
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches: ['*']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Надання необхідних дозволів для публікації пакетів
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    # Крок 1: Отримання коду з репозиторію
+    - uses: actions/checkout@v4
+
+    # Крок 2: Налаштування JDK 17 з кешуванням залежностей Maven
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+
+    # Крок 3: Публікація артефактів в GitHub Packages
+    - name: Publish to GitHub Packages
+      id: publish
+      run: |
+        BASE_VERSION_POM=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          # Видалити -SNAPSHOT з базової версії для імені файлу
+          VERSION_NO_SNAPSHOT=$(echo ${BASE_VERSION_POM} | sed 's/-SNAPSHOT//g')
+          FINAL_NAME="${ARTIFACT_ID}-${VERSION_NO_SNAPSHOT}-pr-${PR_NUMBER}"
+          
+          echo "Збірка Pull Request. Базова версія POM: ${BASE_VERSION_POM}, PR: ${PR_NUMBER}"
+          echo "Встановлення finalName в pom.xml: ${FINAL_NAME}"
+          # Оновлення pom.xml для встановлення фінальної назви артефакту
+          mvn versions:set-property -Dproperty=project.build.finalName -DnewVersion=${FINAL_NAME} -DgenerateBackupPoms=false
+          
+          echo "Пакування з оновленим finalName..."
+          mvn -B package --file pom.xml
+
+          echo "Розгортання PR артефакту. Версія шляху репозиторію: ${BASE_VERSION_POM}, JAR: ${FINAL_NAME}.jar"
+          mvn --batch-mode deploy --file pom.xml -DskipTests
+          
+          echo "version_to_download=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
+          echo "docker_tag=${VERSION_NO_SNAPSHOT}-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
+        else
+          # Стандартне розгортання для не-PR збірок (напр., гілка main)
+          echo "Збірка гілки main або прямий push. Версія: ${BASE_VERSION_POM}"
+          mvn --batch-mode deploy --file pom.xml -DskipTests
+
+          echo "version_to_download=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
+          echo "docker_tag=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,19 +5,15 @@
 #   і має необхідні права для публікації пакетів
 name: Maven Package
 
-# Запускається після успішного завершення CI workflow
+# Запускається як частина CI pipeline або вручну
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  workflow_call:
 
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Запускати лише якщо CI workflow завершився успішно
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     # Надання необхідних дозволів для публікації пакетів
     permissions:
       contents: read
@@ -40,34 +36,20 @@ jobs:
       id: publish
       run: |
         BASE_VERSION_POM=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
 
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          # Видалити -SNAPSHOT з базової версії для імені файлу
-          VERSION_NO_SNAPSHOT=$(echo ${BASE_VERSION_POM} | sed 's/-SNAPSHOT//g')
-          FINAL_NAME="${ARTIFACT_ID}-${VERSION_NO_SNAPSHOT}-pr-${PR_NUMBER}"
-          
-          echo "Збірка Pull Request. Базова версія POM: ${BASE_VERSION_POM}, PR: ${PR_NUMBER}"
-          echo "Встановлення finalName в pom.xml: ${FINAL_NAME}"
-          # Оновлення pom.xml для встановлення фінальної назви артефакту
-          mvn versions:set-property -Dproperty=project.build.finalName -DnewVersion=${FINAL_NAME} -DgenerateBackupPoms=false
-          
-          echo "Пакування з оновленим finalName..."
-          mvn -B package --file pom.xml
-
-          echo "Розгортання PR артефакту. Версія шляху репозиторію: ${BASE_VERSION_POM}, JAR: ${FINAL_NAME}.jar"
-          mvn --batch-mode deploy --file pom.xml -DskipTests
-          
-          echo "version_to_download=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
-          echo "docker_tag=${VERSION_NO_SNAPSHOT}-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
+        # GitHub Packages не підтримує повторний deploy SNAPSHOT версій (422).
+        # Замінюємо -SNAPSHOT на унікальний номер збірки.
+        if [[ "${BASE_VERSION_POM}" == *"-SNAPSHOT"* ]]; then
+          DEPLOY_VERSION="${BASE_VERSION_POM%-SNAPSHOT}-build.${GITHUB_RUN_NUMBER}"
+          echo "SNAPSHOT виявлено. Унікальна версія для deploy: ${DEPLOY_VERSION}"
+          mvn versions:set -DnewVersion="${DEPLOY_VERSION}" -DgenerateBackupPoms=false
         else
-          # Стандартне розгортання для не-PR збірок (напр., гілка main)
-          echo "Збірка гілки main або прямий push. Версія: ${BASE_VERSION_POM}"
-          mvn --batch-mode deploy --file pom.xml -DskipTests
-
-          echo "version_to_download=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
-          echo "docker_tag=${BASE_VERSION_POM}" >> $GITHUB_OUTPUT
+          DEPLOY_VERSION="${BASE_VERSION_POM}"
         fi
+
+        echo "Публікація версії: ${DEPLOY_VERSION}"
+        mvn --batch-mode deploy --file pom.xml -DskipTests
+
+        echo "version_to_download=${DEPLOY_VERSION}" >> $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -34,30 +34,8 @@ jobs:
         server-username: GITHUB_ACTOR
         server-password: GITHUB_TOKEN
 
-    # Крок 3: Діагностика GitHub Packages
-    - name: Діагностика GitHub Packages
-      run: |
-        echo "=== Перевірка settings.xml ==="
-        cat ~/.m2/settings.xml 2>/dev/null || echo "settings.xml не знайдено"
-
-        echo ""
-        echo "=== Перевірка доступу до GitHub Packages ==="
-        curl -s -o /dev/null -w "HTTP Status: %{http_code}\n" \
-          -H "Authorization: token ${GITHUB_TOKEN}" \
-          "https://maven.pkg.github.com/chdbc-samples/college-schedule-app-25/com/college/college-schedule/maven-metadata.xml"
-
-        echo ""
-        echo "=== Тест завантаження POM ==="
-        curl -s -w "\nHTTP Status: %{http_code}\n" \
-          -H "Authorization: token ${GITHUB_TOKEN}" \
-          -X PUT \
-          --data '<project/>' \
-          "https://maven.pkg.github.com/chdbc-samples/college-schedule-app-25/com/college/college-schedule/0.2.0-SNAPSHOT/test-diag.pom"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Крок 4: Публікація артефактів в GitHub Packages
-    - name: Публікація в GitHub Packages
-      run: mvn --batch-mode -e deploy --file pom.xml -DskipTests
+    # Крок 3: Публікація артефактів в GitHub Packages
+    - name: Publish to GitHub Packages
+      run: mvn --batch-mode deploy --file pom.xml -DskipTests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,20 +5,19 @@
 #   і має необхідні права для публікації пакетів
 name: Maven Package
 
-# Запускається при пушах в гілку main або при створенні pull request
+# Запускається після успішного завершення CI workflow
 on:
-  push:
-    branches:
-      - main
-
-  pull_request:
-    branches: ['*']
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Запускати лише якщо CI workflow завершився успішно
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     # Надання необхідних дозволів для публікації пакетів
     permissions:
       contents: read

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -30,26 +30,12 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+        server-id: github
+        server-username: GITHUB_ACTOR
+        server-password: GITHUB_TOKEN
 
     # Крок 3: Публікація артефактів в GitHub Packages
-    - name: Publish to GitHub Packages
-      id: publish
-      run: |
-        BASE_VERSION_POM=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-
-        # GitHub Packages не підтримує повторний deploy SNAPSHOT версій (422).
-        # Замінюємо -SNAPSHOT на унікальний номер збірки.
-        if [[ "${BASE_VERSION_POM}" == *"-SNAPSHOT"* ]]; then
-          DEPLOY_VERSION="${BASE_VERSION_POM%-SNAPSHOT}-build.${GITHUB_RUN_NUMBER}"
-          echo "SNAPSHOT виявлено. Унікальна версія для deploy: ${DEPLOY_VERSION}"
-          mvn versions:set -DnewVersion="${DEPLOY_VERSION}" -DgenerateBackupPoms=false
-        else
-          DEPLOY_VERSION="${BASE_VERSION_POM}"
-        fi
-
-        echo "Публікація версії: ${DEPLOY_VERSION}"
-        mvn --batch-mode deploy --file pom.xml -DskipTests
-
-        echo "version_to_download=${DEPLOY_VERSION}" >> $GITHUB_OUTPUT
+    - name: Публікація в GitHub Packages
+      run: mvn --batch-mode -e -X deploy --file pom.xml -DskipTests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -34,8 +34,30 @@ jobs:
         server-username: GITHUB_ACTOR
         server-password: GITHUB_TOKEN
 
-    # Крок 3: Публікація артефактів в GitHub Packages
+    # Крок 3: Діагностика GitHub Packages
+    - name: Діагностика GitHub Packages
+      run: |
+        echo "=== Перевірка settings.xml ==="
+        cat ~/.m2/settings.xml 2>/dev/null || echo "settings.xml не знайдено"
+
+        echo ""
+        echo "=== Перевірка доступу до GitHub Packages ==="
+        curl -s -o /dev/null -w "HTTP Status: %{http_code}\n" \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          "https://maven.pkg.github.com/chdbc-samples/college-schedule-app-25/com/college/college-schedule/maven-metadata.xml"
+
+        echo ""
+        echo "=== Тест завантаження POM ==="
+        curl -s -w "\nHTTP Status: %{http_code}\n" \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          -X PUT \
+          --data '<project/>' \
+          "https://maven.pkg.github.com/chdbc-samples/college-schedule-app-25/com/college/college-schedule/0.2.0-SNAPSHOT/test-diag.pom"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Крок 4: Публікація артефактів в GitHub Packages
     - name: Публікація в GitHub Packages
-      run: mvn --batch-mode -e -X deploy --file pom.xml -DskipTests
+      run: mvn --batch-mode -e deploy --file pom.xml -DskipTests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -55,11 +55,11 @@ jobs:
               -DtagNameFormat="v@{project.version}" \
               -DdryRun=true -B
           else
-            mvn release:prepare \
-              -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
-              -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
-              -DtagNameFormat="v@{project.version}" \
-              -B
+          mvn release:prepare \
+            -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
+            -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
+            -DtagNameFormat="@{project.version}" \
+            -B
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
-          toTag: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.releaseVersion) || github.sha }}
+          toTag: ${{ github.event.inputs.releaseVersion }}
           configuration: ".github/changelog-config.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,14 +83,16 @@ jobs:
       - name: Попередній перегляд Changelog
         run: |
           echo "## 📋 Changelog Preview" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.changelog.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+          cat <<'EOF' >> $GITHUB_STEP_SUMMARY
+          ${{ steps.changelog.outputs.changelog }}
+          EOF
 
       - name: Create GitHub Release
         if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: v${{ github.event.inputs.releaseVersion }}
+          tag_name: ${{ github.event.inputs.releaseVersion }}
           name: College Schedule Application v${{ github.event.inputs.releaseVersion }}
           body: ${{ steps.changelog.outputs.changelog }}
           draft: true

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -11,12 +11,6 @@ on:
         description: 'Next development version (e.g., 0.3.0-SNAPSHOT)'
         required: true
 
-  # Тимчасовий тригер для тестування в PR (видалити після мержу)
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/maven-release.yml'
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -46,26 +40,15 @@ jobs:
 
       - name: Prepare Release
         run: |
-          # Dry-run для PR, реальний запуск тільки через workflow_dispatch
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "PR режим: dry-run"
-            mvn release:prepare \
-              -DreleaseVersion=0.2.0 \
-              -DdevelopmentVersion=0.3.0-SNAPSHOT \
-              -DtagNameFormat="v@{project.version}" \
-              -DdryRun=true -B
-          else
           mvn release:prepare \
             -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
             -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
             -DtagNameFormat="@{project.version}" \
             -B
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Perform Release
-        if: github.event_name == 'workflow_dispatch'
         run: mvn release:perform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -80,15 +63,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Попередній перегляд Changelog
-        run: |
-          echo "## 📋 Changelog Preview" >> $GITHUB_STEP_SUMMARY
-          cat <<'EOF' >> $GITHUB_STEP_SUMMARY
-          ${{ steps.changelog.outputs.changelog }}
-          EOF
 
       - name: Create GitHub Release
-        if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,74 @@
+# Workflow для автоматичного створення релізів
+name: Maven Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (e.g., 0.2.0)'
+        required: true
+      developmentVersion:
+        description: 'Next development version (e.g., 0.3.0-SNAPSHOT)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+
+      - name: Prepare Release
+        run: |
+          mvn release:prepare \
+          -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
+          -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
+          -DtagNameFormat="v@{project.version}" \
+          -B
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Perform Release
+        run: mvn release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Генерація changelog
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          toTag: v${{ github.event.inputs.releaseVersion }}
+          configuration: ".github/changelog-config.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: v${{ github.event.inputs.releaseVersion }}
+          name: College Schedule Application v${{ github.event.inputs.releaseVersion }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: true
+          prerelease: true
+          files: |
+            target/*.jar
+            README.md

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -11,6 +11,12 @@ on:
         description: 'Next development version (e.g., 0.3.0-SNAPSHOT)'
         required: true
 
+  # Тимчасовий тригер для тестування в PR (видалити після мержу)
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/maven-release.yml'
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,6 +35,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Configure Git user
         run: |
@@ -37,15 +46,26 @@ jobs:
 
       - name: Prepare Release
         run: |
-          mvn release:prepare \
-          -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
-          -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
-          -DtagNameFormat="v@{project.version}" \
-          -B
+          # Dry-run для PR, реальний запуск тільки через workflow_dispatch
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "PR режим: dry-run"
+            mvn release:prepare \
+              -DreleaseVersion=0.2.0 \
+              -DdevelopmentVersion=0.3.0-SNAPSHOT \
+              -DtagNameFormat="v@{project.version}" \
+              -DdryRun=true -B
+          else
+            mvn release:prepare \
+              -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
+              -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
+              -DtagNameFormat="v@{project.version}" \
+              -B
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Perform Release
+        if: github.event_name == 'workflow_dispatch'
         run: mvn release:perform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,12 +75,18 @@ jobs:
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
-          toTag: v${{ github.event.inputs.releaseVersion }}
+          toTag: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.releaseVersion) || github.sha }}
           configuration: ".github/changelog-config.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Попередній перегляд Changelog
+        run: |
+          echo "## 📋 Changelog Preview" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.changelog.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+
       - name: Create GitHub Release
+        if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,15 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <project.scm.id>github</project.scm.id>
   </properties>
+
+  <!-- SCM Information -->
+  <scm>
+    <connection>scm:git:https://github.com/chdbc-samples/college-schedule-app-25.git</connection>
+    <developerConnection>scm:git:https://github.com/chdbc-samples/college-schedule-app-25.git</developerConnection>
+    <url>https://github.com/chdbc-samples/college-schedule-app-25</url>
+  </scm>
   
   <dependencies>  
     <!-- Test framework: JUnit 5, Mockito, Spring Test, AssertJ, etc. -->
@@ -46,6 +54,14 @@
     </dependency>
 
   </dependencies>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/chdbc-samples/college-schedule-app-25</url>
+    </repository>
+  </distributionManagement>
 
   <build>
     <plugins>
@@ -138,6 +154,18 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <!-- Maven Release Plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <connection>scm:git:https://github.com/chdbc-samples/college-schedule-app-25.git</connection>
     <developerConnection>scm:git:https://github.com/chdbc-samples/college-schedule-app-25.git</developerConnection>
     <url>https://github.com/chdbc-samples/college-schedule-app-25</url>
+    <tag>HEAD</tag>
   </scm>
   
   <dependencies>  

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>
-          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <tagNameFormat>@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <releaseProfiles>release</releaseProfiles>
           <goals>deploy</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.college</groupId>
-  <artifactId>college-schedule</artifactId>
+  <artifactId>college-schedule-25</artifactId>
   <packaging>jar</packaging>
   <version>0.2.0-SNAPSHOT</version>
   <name>college-sample</name>


### PR DESCRIPTION
### What does this PR do?

Setup continuous delivery and release automation for the Maven project.

- adds a GitHub Actions workflow to publish Maven artifacts to GitHub Packages
- adds a manual GitHub Actions release workflow that prepares/releases with Maven and creates a draft GitHub Release with a generated changelog
- adds changelog builder configuration for release notes categorization
- updates pom.xml with SCM metadata, GitHub Packages distribution management, and Maven Release Plugin configuration

### Related issue
#6 

### Description for the changelog
```markdown changelog
Set up Maven package publishing, automated releases, and changelog generation for the college schedule app.
```