### PR TITLE
Add Render deploy workflow and improve container deployment config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,3 +267,13 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
+
+  # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
+  deploy-render-pr:
+    name: Deploy Render PR
+    needs: publish-docker
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/render-deploy.yml
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,8 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/college-schedule
           tags: |
             type=ref,event=branch
-            type=sha
+            type=sha,format=long
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
             type=raw,value=${{ steps.project-version.outputs.version }},enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ steps.project-version.outputs.publish_latest == 'true' }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,6 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/college-schedule
           tags: |
             type=ref,event=branch
-            type=sha,format=long
             type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
             type=raw,value=${{ steps.project-version.outputs.version }},enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ steps.project-version.outputs.publish_latest == 'true' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
             type=ref,event=branch
             type=sha
             type=raw,value=${{ steps.project-version.outputs.version }},enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && steps.project-version.outputs.publish_latest == 'true' }}
+            type=raw,value=latest,enable=${{ steps.project-version.outputs.publish_latest == 'true' }}
 
       # Крок 6: збирання та публікація образу Docker-контейнера.
       - name: Build and push Docker image
@@ -66,3 +66,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Show published image addresses
+        shell: bash
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          {
+            echo "## Published Docker Images"
+            echo '```text'
+            printf '%s\n' "$IMAGE_TAGS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,6 +1,9 @@
 name: Render Deploy
 
 on:
+  # Дозволяє викликати workflow з інших workflow, наприклад із CI для деплою з pull request.
+  workflow_call:
+
   # Дозволяє вручну запустити деплой із вказаним тегом образу Docker-контейнера.
   workflow_dispatch:
     inputs:
@@ -10,44 +13,19 @@ on:
         default: latest
         type: string
 
-  # Показує workflow у pull request і дає змогу перевірити його конфігурацію до merge.
-  pull_request:
-
-  # Запускає автодеплой після успішного завершення workflow CI для гілки main.
+  # Запускає деплой після успішного завершення workflow CI для гілки main.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
 
 jobs:
-  # Показує в pull request, який саме образ Docker-контейнера буде використано для деплою.
-  validate:
-    name: Validate Render Deploy Inputs
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    steps:
-      # Крок 1: формування адреси образу Docker-контейнера для pull request.
-      - name: Resolve deploy settings
-        shell: bash
-        run: |
-          image_repo="ghcr.io/${{ github.repository_owner }}/college-schedule"
-          image_url="${image_repo}:pr-${{ github.event.pull_request.number }}"
-
-          echo "Resolved PR image: ${image_url}"
-          {
-            echo "## Render Deploy Validation"
-            echo "Image URL for PR deploy:"
-            echo '```text'
-            echo "${image_url}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
   # Виконує деплой застосунку в Render із вказаним образом Docker-контейнера.
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
-    # Реальний деплой виконується тільки для manual run або workflow_run від CI в main.
+    # Реальний деплой виконується для workflow_call, ручного запуску або після успішного CI в main.
     if: >
+      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
@@ -71,9 +49,22 @@ jobs:
           image_repo="ghcr.io/${{ github.repository_owner }}/college-schedule"
 
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # Для автодеплою після CI в main використовуємо версію з pom.xml.
             version="$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')"
             echo "image_url=${image_repo}:${version}" >> "$GITHUB_OUTPUT"
+
+          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            # Для виклику з CI в pull request формуємо тег у форматі pr-<номер PR>.
+            pr_number="${{ github.event.pull_request.number }}"
+            if [[ -z "$pr_number" ]]; then
+              # Якщо номер PR недоступний у контексті, деплой продовжувати не можна.
+              printf 'Unable to resolve pull request number for workflow_call.\n' >&2
+              exit 1
+            fi
+            echo "image_url=${image_repo}:pr-${pr_number}" >> "$GITHUB_OUTPUT"
+
           else
+            # Для ручного запуску використовуємо тег, переданий через input image_tag.
             echo "image_url=${image_repo}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,120 @@
+name: Render Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker image tag to deploy from GHCR
+        required: false
+        default: latest
+        type: string
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  # Виконує деплой застосунку в Render із вказаним Docker-образом.
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    # Дозволяє запуск вручну або після успішного завершення workflow CI для гілки main.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    # Надає доступ до читання вмісту репозиторію.
+    permissions:
+      contents: read
+
+    steps:
+      # Крок 1: визначення адреси Docker-образу для деплою.
+      - name: Resolve deploy settings
+        id: settings
+        shell: bash
+        run: |
+          image_repo="ghcr.io/${{ github.repository_owner }}/college-schedule"
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "image_url=${image_repo}:sha-${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_url=${image_repo}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Крок 2: перевірка наявності обов'язкових секретів GitHub Actions для Render.
+      - name: Validate Render secrets
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          missing=()
+
+          [[ -z "$RENDER_API_KEY" ]] && missing+=("RENDER_API_KEY")
+          [[ -z "$RENDER_SERVICE_ID" ]] && missing+=("RENDER_SERVICE_ID")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      # Крок 3: запуск нового деплою в Render із заданим Docker-образом.
+      - name: Trigger Render deploy
+        id: deploy
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          IMAGE_URL: ${{ steps.settings.outputs.image_url }}
+        run: |
+          response="$(
+            curl --silent --show-error --fail-with-body \
+              --request POST \
+              --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
+              --header "Authorization: Bearer ${RENDER_API_KEY}" \
+              --header "Content-Type: application/json" \
+              --data "$(jq -cn --arg imageUrl "$IMAGE_URL" '{imageUrl: $imageUrl}')"
+          )"
+
+          deploy_id="$(jq -r '.id // empty' <<<"$response")"
+          if [[ -z "$deploy_id" ]]; then
+            printf 'Render deploy response did not include a deploy id.\n%s\n' "$response" >&2
+            exit 1
+          fi
+
+          echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
+
+      # Крок 4: очікування завершення деплою та перевірка фінального статусу.
+      - name: Wait for Render deploy
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
+        run: |
+          for attempt in {1..40}; do
+            response="$(
+              curl --silent --show-error --fail-with-body \
+                --request GET \
+                --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}" \
+                --header "Authorization: Bearer ${RENDER_API_KEY}"
+            )"
+
+            status="$(jq -r '.status // empty' <<<"$response")"
+            printf 'Render deploy %s status: %s\n' "$DEPLOY_ID" "$status"
+
+            case "$status" in
+              live)
+                exit 0
+                ;;
+              build_failed|update_failed|canceled|cancelled|failed|deactivated)
+                printf 'Render deploy %s finished with failing status: %s\n' "$DEPLOY_ID" "$status" >&2
+                printf '%s\n' "$response" >&2
+                exit 1
+                ;;
+            esac
+
+            sleep 15
+          done
+
+          printf 'Timed out waiting for Render deploy %s to finish.\n' "$DEPLOY_ID" >&2
+          exit 1

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -8,6 +8,8 @@ on:
         required: false
         default: latest
         type: string
+  # Потрібно, щоб workflow було видно та можна було перевірити в pull request до merge в main.
+  pull_request:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -17,9 +19,10 @@ jobs:
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
-    # Дозволяє запуск вручну або після успішного завершення workflow CI для гілки main.
+    # Дозволяє запуск вручну, у pull request або після успішного завершення workflow CI для гілки main.
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     # Надає доступ до читання вмісту репозиторію.

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -56,7 +56,14 @@ jobs:
       contents: read
 
     steps:
-      # Крок 1: визначення адреси образу Docker-контейнера для деплою.
+      # Крок 1: отримання коду для читання версії з pom.xml після workflow_run від CI в main.
+      - name: Checkout repository
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      # Крок 2: визначення адреси образу Docker-контейнера для деплою.
       - name: Resolve deploy settings
         id: settings
         shell: bash
@@ -64,12 +71,13 @@ jobs:
           image_repo="ghcr.io/${{ github.repository_owner }}/college-schedule"
 
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            echo "image_url=${image_repo}:sha-${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            version="$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')"
+            echo "image_url=${image_repo}:${version}" >> "$GITHUB_OUTPUT"
           else
             echo "image_url=${image_repo}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
           fi
 
-      # Крок 2: перевірка наявності обов'язкових секретів GitHub Actions для Render.
+      # Крок 3: перевірка наявності обов'язкових секретів GitHub Actions для Render.
       - name: Validate Render secrets
         shell: bash
         env:
@@ -86,7 +94,7 @@ jobs:
             exit 1
           fi
 
-      # Крок 3: запуск нового деплою в Render із заданим образом Docker-контейнера.
+      # Крок 4: запуск нового деплою в Render із заданим образом Docker-контейнера.
       - name: Trigger Render deploy
         id: deploy
         shell: bash
@@ -112,7 +120,7 @@ jobs:
 
           echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
 
-      # Крок 4: очікування завершення деплою та перевірка фінального статусу.
+      # Крок 5: очікування завершення деплою та перевірка фінального статусу.
       - name: Wait for Render deploy
         shell: bash
         env:

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -23,10 +23,10 @@ jobs:
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
-    # Реальний деплой виконується для workflow_call, ручного запуску або після успішного CI в main.
+    # Реальний деплой виконується для виклику з pull request, ручного запуску або після успішного CI в main.
     if: >
-      github.event_name == 'workflow_call' ||
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     # Надає доступ до читання вмісту репозиторію.

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -53,12 +53,12 @@ jobs:
             version="$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')"
             echo "image_url=${image_repo}:${version}" >> "$GITHUB_OUTPUT"
 
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Для виклику з CI в pull request формуємо тег у форматі pr-<номер PR>.
             pr_number="${{ github.event.pull_request.number }}"
             if [[ -z "$pr_number" ]]; then
               # Якщо номер PR недоступний у контексті, деплой продовжувати не можна.
-              printf 'Unable to resolve pull request number for workflow_call.\n' >&2
+              printf 'Unable to resolve pull request number for pull_request context.\n' >&2
               exit 1
             fi
             echo "image_url=${image_repo}:pr-${pr_number}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,6 +1,7 @@
 name: Render Deploy
 
 on:
+  # Дозволяє вручну запустити деплой із вказаним тегом образу Docker-контейнера.
   workflow_dispatch:
     inputs:
       image_tag:
@@ -8,21 +9,46 @@ on:
         required: false
         default: latest
         type: string
-  # Потрібно, щоб workflow було видно та можна було перевірити в pull request до merge в main.
+
+  # Показує workflow у pull request і дає змогу перевірити його конфігурацію до merge.
   pull_request:
+
+  # Запускає автодеплой після успішного завершення workflow CI для гілки main.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
 
 jobs:
-  # Виконує деплой застосунку в Render із вказаним Docker-образом.
+  # Показує в pull request, який саме образ Docker-контейнера буде використано для деплою.
+  validate:
+    name: Validate Render Deploy Inputs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      # Крок 1: формування адреси образу Docker-контейнера для pull request.
+      - name: Resolve deploy settings
+        shell: bash
+        run: |
+          image_repo="ghcr.io/${{ github.repository_owner }}/college-schedule"
+          image_url="${image_repo}:pr-${{ github.event.pull_request.number }}"
+
+          echo "Resolved PR image: ${image_url}"
+          {
+            echo "## Render Deploy Validation"
+            echo "Image URL for PR deploy:"
+            echo '```text'
+            echo "${image_url}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Виконує деплой застосунку в Render із вказаним образом Docker-контейнера.
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
-    # Дозволяє запуск вручну, у pull request або після успішного завершення workflow CI для гілки main.
+    # Реальний деплой виконується тільки для manual run або workflow_run від CI в main.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     # Надає доступ до читання вмісту репозиторію.
@@ -30,7 +56,7 @@ jobs:
       contents: read
 
     steps:
-      # Крок 1: визначення адреси Docker-образу для деплою.
+      # Крок 1: визначення адреси образу Docker-контейнера для деплою.
       - name: Resolve deploy settings
         id: settings
         shell: bash
@@ -60,7 +86,7 @@ jobs:
             exit 1
           fi
 
-      # Крок 3: запуск нового деплою в Render із заданим Docker-образом.
+      # Крок 3: запуск нового деплою в Render із заданим образом Docker-контейнера.
       - name: Trigger Render deploy
         id: deploy
         shell: bash

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/college-db}
-server.port=8081
+server.port=${PORT:8081}


### PR DESCRIPTION
### What does this PR do?
- adds a new GitHub Actions workflow to deploy the application to Render from a Docker image published to GitHub Container Registry
- updates the Docker publish workflow to expose published image tags in the workflow summary and keep publishing latest for non-snapshot versions

### Related issue
#23 

### Description for the changelog
```markdown changelog
  Add Render deployment workflow and support PORT-based runtime configuration
```