### PR TITLE
Add E2E UI tests and GitHub Action to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
     uses: ./.github/workflows/render-deploy.yml
     secrets: inherit
 
-  # Етап 8: запустити E2E UI-тести проти вже розгорнутого Render UR
+  # Етап 8: запустити E2E UI-тести проти програми, яка була успішно розгорнута на Render.com
   e2e-ui-tests:
     name: E2E UI Tests
     needs: deploy-render-pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
   # Етап 8: запустити E2E UI-тести проти вже розгорнутого Render UR
   e2e-ui-tests:
     name: E2E UI Tests
-    needs: build
+    needs: deploy-render-pr
     if: github.event_name == 'pull_request'
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,20 +268,17 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
 
-  # # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
-  # deploy-render-pr:
-  #   name: Deploy Render PR
-  #   needs: publish-docker
-  #   if: github.event_name == 'pull_request'
-  #   permissions:
-  #     contents: read
-  #   uses: ./.github/workflows/render-deploy.yml
-  #   secrets: inherit
+  # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
+  deploy-render-pr:
+    name: Deploy Render PR
+    needs: publish-docker
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/render-deploy.yml
+    secrets: inherit
 
-  # Етап 8: тимчасово запускати E2E UI-тести проти вже розгорнутого Render URL,
-  # не чекаючи PR-specific deploy.
-  # TODO: повернути нормальний flow після стабілізації E2E bootstrap:
-  # needs: deploy-render-pr і application_url з needs.deploy-render-pr.outputs.application_url.
+  # Етап 8: запустити E2E UI-тести проти вже розгорнутого Render UR
   e2e-ui-tests:
     name: E2E UI Tests
     needs: build
@@ -290,4 +287,4 @@ jobs:
       contents: read
     uses: ./.github/workflows/run-e2e-test.yml
     with:
-      application_url: https://college-schedule-app-0-3-0.onrender.com
+      application_url: ${{ needs.deploy-render-pr.outputs.application_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,3 +277,13 @@ jobs:
       contents: read
     uses: ./.github/workflows/render-deploy.yml
     secrets: inherit
+
+  e2e-ui-tests:
+    name: E2E UI Tests
+    needs: deploy-render-pr
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run-e2e-test.yml
+    with:
+      application_url: ${{ needs.deploy-render-pr.outputs.application_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,22 +268,26 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
 
-  # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
-  deploy-render-pr:
-    name: Deploy Render PR
-    needs: publish-docker
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-    uses: ./.github/workflows/render-deploy.yml
-    secrets: inherit
+  # # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
+  # deploy-render-pr:
+  #   name: Deploy Render PR
+  #   needs: publish-docker
+  #   if: github.event_name == 'pull_request'
+  #   permissions:
+  #     contents: read
+  #   uses: ./.github/workflows/render-deploy.yml
+  #   secrets: inherit
 
+  # Етап 8: тимчасово запускати E2E UI-тести проти вже розгорнутого Render URL,
+  # не чекаючи PR-specific deploy.
+  # TODO: повернути нормальний flow після стабілізації E2E bootstrap:
+  # needs: deploy-render-pr і application_url з needs.deploy-render-pr.outputs.application_url.
   e2e-ui-tests:
     name: E2E UI Tests
-    needs: deploy-render-pr
+    needs: build
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
     uses: ./.github/workflows/run-e2e-test.yml
     with:
-      application_url: ${{ needs.deploy-render-pr.outputs.application_url }}
+      application_url: https://college-schedule-app-0-3-0.onrender.com

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -3,6 +3,10 @@ name: Render Deploy
 on:
   # Дозволяє викликати workflow з інших workflow, наприклад із CI для деплою з pull request.
   workflow_call:
+    outputs:
+      application_url:
+        description: Deployed application base URL
+        value: ${{ jobs.deploy.outputs.application_url }}
 
   # Дозволяє вручну запустити деплой із вказаним тегом образу Docker-контейнера.
   workflow_dispatch:
@@ -23,6 +27,8 @@ jobs:
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
+    outputs:
+      application_url: ${{ steps.service.outputs.application_url }}
     # Реальний деплой виконується для виклику з pull request, ручного запуску або після успішного CI в main.
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -146,3 +152,34 @@ jobs:
 
           printf 'Timed out waiting for Render deploy %s to finish.\n' "$DEPLOY_ID" >&2
           exit 1
+
+      - name: Resolve deployed application URL
+        id: service
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          response="$(
+            curl --silent --show-error --fail-with-body \
+              --request GET \
+              --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}" \
+              --header "Authorization: Bearer ${RENDER_API_KEY}"
+          )"
+
+          application_url="$(
+            jq -r '
+              .service.serviceDetails.url //
+              .serviceDetails.url //
+              .service.url //
+              .url //
+              empty
+            ' <<<"$response"
+          )"
+
+          if [[ -z "$application_url" ]]; then
+            printf 'Unable to resolve deployed application URL from Render service response.\n%s\n' "$response" >&2
+            exit 1
+          fi
+
+          echo "application_url=${application_url}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -1,0 +1,70 @@
+name: run-e2e-test
+
+on:
+  # Дозволяє викликати workflow з інших workflow, передаючи URL уже розгорнутого застосунку.
+  workflow_call:
+    inputs:
+      application_url:
+        description: Deployed application base URL for UI tests
+        required: true
+        type: string
+  # Дозволяє вручну запустити E2E UI-тести проти вказаного deployed URL.
+  workflow_dispatch:
+    inputs:
+      application_url:
+        description: Deployed application base URL for UI tests
+        required: true
+        type: string
+
+jobs:
+  # Виконує happy-path E2E UI-тести в Selenium Chromium проти вже розгорнутого застосунку.
+  e2e-ui-tests:
+    name: E2E UI Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      selenium:
+        image: selenium/standalone-chromium:latest
+        ports:
+          - 4444:4444
+
+    steps:
+      # Крок 1: отримання коду репозиторію з E2E тестами та Maven-конфігурацією.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Крок 2: налаштування Java та кешу Maven для запуску E2E UI тестів на runner.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      # Крок 3: підготовка директорій для логів, screenshot і відео тестового прогону.
+      - name: Prepare artifact directories
+        shell: bash
+        run: mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
+
+      # Крок 4: запуск bootstrap-скрипта `workflows/scripts/run-e2e-test.sh`,
+      # який створює Selenium session, отримує CDP URL і запускає `mvn -P e2e-ui`.
+      - name: Run E2E UI tests
+        shell: bash
+        env:
+          E2E_BASE_URL: ${{ inputs.application_url }}
+          E2E_ARTIFACTS_DIR: target/e2e-artifacts
+        run: |
+          chmod +x workflows/scripts/run-e2e-test.sh
+          workflows/scripts/run-e2e-test.sh
+
+      # Крок 5: завантаження E2E звітів, логів, screenshot і screencast як artifacts pipeline.
+      - name: Upload E2E reports and media
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ui-test-artifacts
+          path: |
+            target/failsafe-reports/**
+            target/ci-logs/**
+            target/e2e-artifacts/**
+          if-no-files-found: warn

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   # Виконує happy-path E2E UI-тести в Selenium Chromium проти вже розгорнутого застосунку.
   e2e-ui-tests:
-    name: E2E UI Tests
+    name: Run E2E UI Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:

--- a/README.md
+++ b/README.md
@@ -307,64 +307,74 @@ Audit done.
 2026-04-12 11:24:03.443  INFO 13732 --- [nio-8081-exec-1] org.mongodb.driver.connection            : Opened connection [connectionId{localValue:3, serverValue:9}] to localhost:27017
 ```
 
-## CI (GitHub Actions)
-
-Файл workflow: `.github/workflows/ci.yml`
-
-CI-pipeline запускається автоматично для:
-1. Pull request (`opened`, `synchronize`, `reopened`) у гілки `main` та `release/*`
-2. Push у гілки `main` та `release/*`
-
-Етапи pipeline:
-1. `static-analysis`:
-- Запускає Checkstyle (`mvn -B -DskipTests checkstyle:check`)
-- Завершує CI з помилкою, якщо правила порушено
-2. `unit-tests`:
-- Запускає `mvn -B -Dcheckstyle.skip=true -DskipIntegrationTests=true test`
-- Публікує `Surefire`-звіти та артефакти покриття unit-тестів
-- Додає в `GITHUB_STEP_SUMMARY` підсумок line coverage для unit-тестів
-3. `integration-tests`:
-- Запускає `mvn -B -Dcheckstyle.skip=true -DskipUnitTests=true verify`
-- Піднімає ізольований MongoDB через Testcontainers
-- Публікує `Failsafe`-звіти та артефакти покриття integration-тестів
-- Додає в `GITHUB_STEP_SUMMARY` окремий підсумок line coverage для `com.college.Schedule`
-- Додає в `GITHUB_STEP_SUMMARY` окремий підсумок line coverage для `com.college.ScheduleController`
-4. `build`:
-- Запускає `mvn -B -DskipUnitTests=true -DskipIntegrationTests=true package`
-- Створює JAR після успішного проходження unit та integration тестів
-5. `publish`:
-- Використовує reusable workflow `.github/workflows/maven-publish.yml`
-- Запускається лише після успішного завершення етапу `build`
-
-Артефакти та звіти:
-1. Артефакт збірки: `target/*.jar`
-2. Звіти тестів: `target/surefire-reports/**`
-3. Звіти integration-тестів: `target/failsafe-reports/**`
-4. Звіти unit test coverage: `target/site/jacoco/**`, `target/jacoco.exec`
-5. Звіти integration test coverage: `target/site/jacoco-integration-tests/**`, `target/jacoco-integration-tests.exec`
-6. При падінні static analysis workflow завантажує логи: `target/ci-logs/**`
-7. При падінні unit-тестів workflow завантажує логи: `target/ci-logs/**`
-8. При падінні integration-тестів workflow завантажує логи `target/ci-logs/**` і додатково звіти `target/failsafe-reports/**` та `target/site/jacoco-integration-tests/**`
-
-## Тестування та покриття
+## Тестування
 
 Поточний стан:
-1. Unit-тести написані на **JUnit 5**.
+1. Unit-тести написані на **JUnit 5** і запускаються через **Surefire**.
 2. Integration-тести запускаються через **Failsafe** і використовують **Testcontainers MongoDB**.
-3. Для покриття використовується **JaCoCo**.
-4. У `pom.xml` налаштовано мінімальне покриття **75% line coverage** для unit-тестів (перевірка на етапі `package`) і **100% line coverage** для інтеграційних тестів для класів `com.college.Schedule` та `com.college.ScheduleController` (перевірка на етапі `verify`).
+3. E2E UI-тести написані на **Playwright for Java** у класі `src/test/java/com/college/ScheduleHappyPathE2ETests.java`.
+4. Для покриття використовується **JaCoCo**.
+5. У `pom.xml` налаштовано мінімальне покриття **75% line coverage** для unit-тестів і **100% line coverage** для інтеграційних тестів для `com.college.Schedule` та `com.college.ScheduleController`.
 
 Локальний запуск:
 1. Тільки unit-тести:
 `mvn test`
 2. Тільки integration-тести:
 `mvn -DskipUnitTests=true verify`
-3. Повна перевірка (unit + integration + JaCoCo):
+3. Тільки E2E UI-тести проти вже розгорнутого середовища:
+`mvn -B -P e2e-ui '-Dcheckstyle.skip=true' '-DskipUnitTests=true' '-DskipIntegrationTests=true' '-De2e.base-url=https://your-app.onrender.com' verify`
+4. Повна перевірка:
 `mvn verify`
 
 Звіти:
-1. JUnit/Surefire: `target/surefire-reports/`
-2. JUnit/Failsafe: `target/failsafe-reports/`
-3. Unit JaCoCo HTML: `target/site/jacoco/index.html`
-4. Integration JaCoCo HTML: `target/site/jacoco-integration-tests/index.html`
-5. Unit JaCoCo CSV: `target/site/jacoco/jacoco.csv`
+1. Unit test reports: `target/surefire-reports/`
+2. Integration and E2E test reports: `target/failsafe-reports/`
+3. E2E media: `target/e2e-artifacts/videos/`, `target/e2e-artifacts/screenshots/`
+4. Unit coverage: `target/site/jacoco/`
+5. Integration coverage: `target/site/jacoco-integration-tests/`
+
+## E2E UI тести
+
+Конфігурація:
+1. URL розгорнутого застосунку передається через JVM property `e2e.base-url` або змінну середовища `E2E_BASE_URL`.
+2. Якщо URL не передано, тести завершуються зі статусом **skipped** без падіння збірки.
+3. Для запуску через Selenium Grid Playwright може під'єднатися до Chromium CDP endpoint, переданого через `e2e.selenium-cdp-url` або `E2E_SELENIUM_CDP_URL`.
+4. Відео проходження тестів записується в `target/e2e-artifacts/videos/`.
+5. При падінні тесту screenshot записується в `target/e2e-artifacts/screenshots/`.
+
+Локальний запуск проти Render або іншого deployed URL в PowerShell:
+```powershell
+$env:E2E_BASE_URL="https://your-app.onrender.com"
+mvn -B -P e2e-ui `
+  '-Dcheckstyle.skip=true' `
+  '-DskipUnitTests=true' `
+  '-DskipIntegrationTests=true' `
+  verify
+```
+
+## CI (GitHub Actions)
+
+Основний workflow: `.github/workflows/ci.yml`
+
+CI запускається автоматично для:
+1. Pull request (`opened`, `synchronize`, `reopened`) у гілки `main` та `release/*`
+2. Push у гілки `main` та `release/*`
+
+Актуальна послідовність job:
+1. `static-analysis`
+2. `unit-tests`
+3. `integration-tests`
+4. `build`
+5. `publish`
+6. `publish-docker`
+7. `deploy-render-pr` для pull request
+8. `e2e-ui-tests` для pull request після успішного `deploy-render-pr`
+
+Пов'язані workflow:
+1. `.github/workflows/render-deploy.yml` виконує деплой у Render і повертає `application_url`
+2. `.github/workflows/run-e2e-test.yml` приймає `application_url`, піднімає `selenium/standalone-chromium:latest` як service container, викликає `workflows/scripts/run-e2e-test.sh` і завантажує artifacts
+3. `workflows/scripts/run-e2e-test.sh` створює Selenium session, налаштовує CDP URL для Playwright і запускає `mvn -P e2e-ui` на GitHub runner
+
+GitHub Actions:
+1. `run-e2e-test` також підтримує ручний запуск через `workflow_dispatch` з обов'язковим параметром `application_url`
+2. E2E workflow завантажує screenshots, відео, `failsafe`-звіти та логи як pipeline artifacts

--- a/README.md
+++ b/README.md
@@ -368,12 +368,12 @@ CI запускається автоматично для:
 5. `publish`
 6. `publish-docker`
 7. `deploy-render-pr` для pull request
-8. `e2e-ui-tests` для pull request після успішного `deploy-render-pr`
+8. `e2e-ui-tests` для pull request після успішного `build`, тимчасово проти `https://college-schedule-app-0-3-0.onrender.com`
 
 Пов'язані workflow:
-1. `.github/workflows/render-deploy.yml` виконує деплой у Render і повертає `application_url`
-2. `.github/workflows/run-e2e-test.yml` приймає `application_url`, піднімає `selenium/standalone-chromium:latest` як service container, викликає `workflows/scripts/run-e2e-test.sh` і завантажує artifacts
-3. `workflows/scripts/run-e2e-test.sh` створює Selenium session, налаштовує CDP URL для Playwright і запускає `mvn -P e2e-ui` на GitHub runner
+1. `.github/workflows/run-e2e-test.yml` приймає `application_url`, піднімає `selenium/standalone-chromium:latest` як service container, викликає `workflows/scripts/run-e2e-test.sh` і завантажує artifacts
+2. `workflows/scripts/run-e2e-test.sh` створює Selenium session, налаштовує CDP URL для Playwright і запускає `mvn -P e2e-ui` на GitHub runner
+3. У `CI` workflow job `e2e-ui-tests` тимчасово використовує фіксований URL `https://college-schedule-app-0-3-0.onrender.com`
 
 GitHub Actions:
 1. `run-e2e-test` також підтримує ручний запуск через `workflow_dispatch` з обов'язковим параметром `application_url`

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,10 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.scm.id>github</project.scm.id>
     <testcontainers.version>1.21.4</testcontainers.version>
+    <playwright.version>1.55.0</playwright.version>
     <skipUnitTests>false</skipUnitTests>
     <skipIntegrationTests>false</skipIntegrationTests>
+    <skipE2ETests>false</skipE2ETests>
   </properties>
 
   <!-- Інформація про SCM -->
@@ -60,6 +62,12 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>mongodb</artifactId>
         <version>${testcontainers.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.microsoft.playwright</groupId>
+        <artifactId>playwright</artifactId>
+        <version>${playwright.version}</version>
         <scope>test</scope>
     </dependency>
 
@@ -124,6 +132,7 @@
           <skipTests>${skipUnitTests}</skipTests>
           <excludes>
             <exclude>**/*IntegrationTests.java</exclude>
+            <exclude>**/*E2ETests.java</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -288,4 +297,35 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>e2e-ui</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.5.1</version>
+            <configuration>
+              <useModulePath>false</useModulePath>
+              <skipITs>${skipE2ETests}</skipITs>
+              <includes>
+                <include>**/*E2ETests.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>run-e2e-ui-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +58,9 @@ class ScheduleHappyPathE2ETests {
     @BeforeEach
     void setUp() {
         baseUrl = resolveBaseUrl();
-        Assumptions.assumeTrue(baseUrl != null && !baseUrl.isBlank(),
-            "Set e2e.base-url or E2E_BASE_URL to run E2E UI tests.");
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalStateException("Set e2e.base-url or E2E_BASE_URL to run E2E UI tests.");
+        }
         seleniumCdpUrl = resolveOptionalValue(SELENIUM_CDP_URL_PROPERTY, SELENIUM_CDP_URL_ENV);
         pageReadyTimeoutMillis = resolvePageReadyTimeoutMillis();
         artifactsDir = resolveArtifactsDir();

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -1,0 +1,330 @@
+package com.college;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.ScreenshotType;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScheduleHappyPathE2ETests {
+
+    private static final String BASE_URL_PROPERTY = "e2e.base-url";
+    private static final String BASE_URL_ENV = "E2E_BASE_URL";
+    private static final String SELENIUM_CDP_URL_PROPERTY = "e2e.selenium-cdp-url";
+    private static final String SELENIUM_CDP_URL_ENV = "E2E_SELENIUM_CDP_URL";
+    private static final String ARTIFACTS_DIR_PROPERTY = "e2e.artifacts-dir";
+    private static final String ARTIFACTS_DIR_ENV = "E2E_ARTIFACTS_DIR";
+    private static final String PAGE_READY_TIMEOUT_MILLIS_PROPERTY = "e2e.page-ready-timeout-millis";
+    private static final String PAGE_READY_TIMEOUT_MILLIS_ENV = "E2E_PAGE_READY_TIMEOUT_MILLIS";
+    private static final String SCHEDULE_PAGE_TITLE = "\u0420\u043e\u0437\u043a\u043b\u0430\u0434 \u043a\u043e\u043b\u0435\u0434\u0436\u0443";
+    private static final String RENDER_HOST_SUFFIX = ".onrender.com";
+    private static final int WAIT_TIMEOUT_MILLIS = 15000;
+    private static final int POLL_INTERVAL_MILLIS = 250;
+    private static final int DEFAULT_PAGE_READY_TIMEOUT_MILLIS = 180000;
+    private static final int DEFAULT_TIMEOUT_MILLIS = 30000;
+    private static final int RENDER_TIMEOUT_MILLIS = 180000;
+    private static final int VIEWPORT_WIDTH = 1440;
+    private static final int VIEWPORT_HEIGHT = 1200;
+    private static final int VIDEO_WIDTH = 1280;
+    private static final int VIDEO_HEIGHT = 720;
+
+    private String baseUrl;
+    private String seleniumCdpUrl;
+    private int pageReadyTimeoutMillis;
+    private Path artifactsDir;
+    private Path videosDir;
+    private Path screenshotsDir;
+    private Playwright playwright;
+    private Browser browser;
+    private BrowserContext browserContext;
+    private Page page;
+    private String createdCourseName;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = resolveBaseUrl();
+        Assumptions.assumeTrue(baseUrl != null && !baseUrl.isBlank(),
+            "Set e2e.base-url or E2E_BASE_URL to run E2E UI tests.");
+        seleniumCdpUrl = resolveOptionalValue(SELENIUM_CDP_URL_PROPERTY, SELENIUM_CDP_URL_ENV);
+        pageReadyTimeoutMillis = resolvePageReadyTimeoutMillis();
+        artifactsDir = resolveArtifactsDir();
+        videosDir = artifactsDir.resolve("videos");
+        screenshotsDir = artifactsDir.resolve("screenshots");
+        createDirectory(videosDir);
+        createDirectory(screenshotsDir);
+
+        playwright = Playwright.create();
+        browser = createBrowser();
+        browserContext = browser.newContext(new Browser.NewContextOptions()
+            .setRecordVideoDir(videosDir)
+            .setRecordVideoSize(VIDEO_WIDTH, VIDEO_HEIGHT)
+            .setViewportSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT));
+        page = browserContext.newPage();
+        page.setDefaultTimeout(resolvePlaywrightTimeoutMillis());
+        page.setDefaultNavigationTimeout(resolvePlaywrightTimeoutMillis());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (page != null && createdCourseName != null) {
+            try {
+                deleteScheduleRow(createdCourseName);
+            } catch (Exception exception) {
+                // Preserve the original test failure; cleanup is best effort.
+            } finally {
+                createdCourseName = null;
+            }
+        }
+
+        if (browserContext != null) {
+            browserContext.close();
+        }
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @Test
+    void scheduleHappyPathCreatesAndDeletesEntry() {
+        runWithDiagnostics("schedule-happy-path-creates-and-deletes-entry", () -> {
+            String uniqueSuffix = String.valueOf(Instant.now().toEpochMilli());
+            String uniqueCourseName = "E2E Course " + uniqueSuffix;
+            String uniqueStudentName = "E2E Student " + uniqueSuffix;
+            createdCourseName = uniqueCourseName;
+
+            page.navigate(baseUrl + "/add");
+            assertThat(page.locator("form").count()).isEqualTo(1);
+
+            setInputValue("studentFirstName", uniqueStudentName);
+            setInputValue("studentLastName", "Tester");
+            setInputValue("teacherFirstName", "UI");
+            setInputValue("teacherLastName", "Teacher");
+            setInputValue("courseName", uniqueCourseName);
+            setInputValue("departmentName", "QA");
+            setInputValue("roomNumber", "301");
+            setInputValue("semester", "Spring");
+            setInputValue("year", "2026");
+            setInputValue("startTime", "09:00:00");
+            setInputValue("endTime", "10:30:00");
+
+            page.locator("button[type='submit']").click();
+            page.waitForURL(baseUrl + "/");
+            waitForSchedulePageHeader();
+
+            Locator createdRow = waitForRowContaining(uniqueCourseName,
+                "Created schedule row did not appear on the main page.");
+            assertThat(createdRow.textContent())
+                .contains(uniqueStudentName)
+                .contains(uniqueCourseName);
+
+            deleteScheduleRow(uniqueCourseName);
+            createdCourseName = null;
+        });
+    }
+
+    private void deleteScheduleRow(String uniqueCourseName) {
+        page.navigate(baseUrl + "/");
+        waitForSchedulePageHeader();
+
+        Locator rowToDelete = findRowContaining(uniqueCourseName);
+        if (rowToDelete == null) {
+            return;
+        }
+
+        rowToDelete.locator("button[type='submit']").click();
+        page.waitForURL(baseUrl + "/");
+        waitForSchedulePageHeader();
+        waitFor(() -> findRowContaining(uniqueCourseName) == null,
+            "Deleted schedule row is still visible on the main page.");
+
+        assertThat(page.locator("body").textContent()).doesNotContain(uniqueCourseName);
+    }
+
+    private Locator waitForRowContaining(String text, String failureMessage) {
+        waitFor(() -> findRowContaining(text) != null, failureMessage);
+        return findRowContaining(text);
+    }
+
+    private Locator findRowContaining(String text) {
+        Locator rows = page.locator("tbody tr");
+        int count = rows.count();
+        for (int index = 0; index < count; index++) {
+            Locator row = rows.nth(index);
+            String rowText = row.textContent();
+            if (rowText != null && rowText.contains(text)) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    private void setInputValue(String fieldName, String value) {
+        page.locator("[name='" + fieldName + "']").fill(value);
+    }
+
+    private void waitForSchedulePageHeader() {
+        page.locator("h1")
+            .filter(new Locator.FilterOptions().setHasText(SCHEDULE_PAGE_TITLE))
+            .first()
+            .waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE)
+                .setTimeout((double) pageReadyTimeoutMillis));
+    }
+
+    private void waitFor(BooleanSupplier condition, String failureMessage) {
+        long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            page.waitForTimeout(POLL_INTERVAL_MILLIS);
+        }
+        throw new AssertionError(failureMessage);
+    }
+
+    private String resolveBaseUrl() {
+        String configuredUrl = resolveOptionalValue(BASE_URL_PROPERTY, BASE_URL_ENV);
+        if (configuredUrl == null || configuredUrl.isBlank()) {
+            return null;
+        }
+
+        return normalizeBaseUrl(configuredUrl);
+    }
+
+    private String normalizeBaseUrl(String configuredUrl) {
+        String normalizedUrl = configuredUrl.endsWith("/")
+            ? configuredUrl.substring(0, configuredUrl.length() - 1)
+            : configuredUrl;
+
+        URI uri = URI.create(normalizedUrl);
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            throw new IllegalStateException(
+                "E2E base URL must be an absolute URL, for example https://example.onrender.com"
+            );
+        }
+
+        return normalizedUrl;
+    }
+
+    private String resolveOptionalValue(String propertyName, String envName) {
+        String configuredValue = System.getProperty(propertyName);
+        if (configuredValue == null || configuredValue.isBlank()) {
+            configuredValue = System.getenv(envName);
+        }
+        return configuredValue;
+    }
+
+    private Browser createBrowser() {
+        if (seleniumCdpUrl != null && !seleniumCdpUrl.isBlank()) {
+            return playwright.chromium().connectOverCDP(seleniumCdpUrl);
+        }
+
+        return playwright.chromium().launch(new BrowserType.LaunchOptions()
+            .setHeadless(true)
+            .setArgs(List.of("--disable-dev-shm-usage", "--no-sandbox")));
+    }
+
+    private Path resolveArtifactsDir() {
+        String configuredArtifactsDir = resolveOptionalValue(ARTIFACTS_DIR_PROPERTY, ARTIFACTS_DIR_ENV);
+        if (configuredArtifactsDir == null || configuredArtifactsDir.isBlank()) {
+            configuredArtifactsDir = "target/e2e-artifacts";
+        }
+        return Paths.get(configuredArtifactsDir).toAbsolutePath().normalize();
+    }
+
+    private int resolvePageReadyTimeoutMillis() {
+        String configuredTimeout = resolveOptionalValue(
+            PAGE_READY_TIMEOUT_MILLIS_PROPERTY,
+            PAGE_READY_TIMEOUT_MILLIS_ENV
+        );
+        if (configuredTimeout == null || configuredTimeout.isBlank()) {
+            return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_PAGE_READY_TIMEOUT_MILLIS;
+        }
+        return Integer.parseInt(configuredTimeout);
+    }
+
+    private double resolvePlaywrightTimeoutMillis() {
+        return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_TIMEOUT_MILLIS;
+    }
+
+    private boolean isRenderBaseUrl() {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return false;
+        }
+
+        URI uri = URI.create(baseUrl);
+        String host = uri.getHost();
+        return host != null && host.endsWith(RENDER_HOST_SUFFIX);
+    }
+
+    private void createDirectory(Path directory) {
+        try {
+            Files.createDirectories(directory);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Unable to create E2E artifacts directory " + directory, exception);
+        }
+    }
+
+    private void runWithDiagnostics(String testName, CheckedRunnable testBody) {
+        try {
+            testBody.run();
+        } catch (Throwable throwable) {
+            captureFailureScreenshot(testName);
+            rethrowUnchecked(throwable);
+        }
+    }
+
+    private void captureFailureScreenshot(String testName) {
+        if (page == null) {
+            return;
+        }
+
+        Path screenshotPath = screenshotsDir.resolve(buildArtifactFileName(testName, "png"));
+        page.screenshot(new Page.ScreenshotOptions()
+            .setPath(screenshotPath)
+            .setFullPage(true)
+            .setType(ScreenshotType.PNG));
+    }
+
+    private String buildArtifactFileName(String testName, String extension) {
+        return sanitizeFileName(testName) + "-" + Instant.now().toEpochMilli() + "." + extension;
+    }
+
+    private String sanitizeFileName(String value) {
+        return value.replaceAll("[^a-zA-Z0-9-_]+", "-");
+    }
+
+    private void rethrowUnchecked(Throwable throwable) {
+        if (throwable instanceof RuntimeException) {
+            throw (RuntimeException) throwable;
+        }
+        if (throwable instanceof Error) {
+            throw (Error) throwable;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    @FunctionalInterface
+    private interface CheckedRunnable {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 
 class ScheduleHappyPathE2ETests {
 
+    // Підтримуємо конфігурацію через JVM properties та environment variables,
+    // щоб один і той самий тест можна було запускати локально й у CI.
     private static final String BASE_URL_PROPERTY = "e2e.base-url";
     private static final String BASE_URL_ENV = "E2E_BASE_URL";
     private static final String SELENIUM_CDP_URL_PROPERTY = "e2e.selenium-cdp-url";
@@ -31,7 +33,7 @@ class ScheduleHappyPathE2ETests {
     private static final String ARTIFACTS_DIR_ENV = "E2E_ARTIFACTS_DIR";
     private static final String PAGE_READY_TIMEOUT_MILLIS_PROPERTY = "e2e.page-ready-timeout-millis";
     private static final String PAGE_READY_TIMEOUT_MILLIS_ENV = "E2E_PAGE_READY_TIMEOUT_MILLIS";
-    private static final String SCHEDULE_PAGE_TITLE = "\u0420\u043e\u0437\u043a\u043b\u0430\u0434 \u043a\u043e\u043b\u0435\u0434\u0436\u0443";
+    private static final String SCHEDULE_PAGE_TITLE = "Розклад коледжу";
     private static final String RENDER_HOST_SUFFIX = ".onrender.com";
     private static final int WAIT_TIMEOUT_MILLIS = 15000;
     private static final int POLL_INTERVAL_MILLIS = 250;
@@ -55,9 +57,12 @@ class ScheduleHappyPathE2ETests {
     private Page page;
     private String createdCourseName;
 
+    // Ініціалізуємо Playwright, директорії артефактів і браузерне оточення перед кожним тестом.
     @BeforeEach
     void setUp() {
         baseUrl = resolveBaseUrl();
+
+        // Для E2E URL є обов'язковим, тому відсутність конфігурації вважаємо помилкою тестового запуску.
         if (baseUrl == null || baseUrl.isBlank()) {
             throw new IllegalStateException("Set e2e.base-url or E2E_BASE_URL to run E2E UI tests.");
         }
@@ -71,6 +76,8 @@ class ScheduleHappyPathE2ETests {
 
         playwright = Playwright.create();
         browser = createBrowser();
+        
+        // Записуємо відео кожного прогону, щоб у CI можна було відтворити UI-поведінку.
         browserContext = browser.newContext(new Browser.NewContextOptions()
             .setRecordVideoDir(videosDir)
             .setRecordVideoSize(VIDEO_WIDTH, VIDEO_HEIGHT)
@@ -80,10 +87,12 @@ class ScheduleHappyPathE2ETests {
         page.setDefaultNavigationTimeout(resolvePlaywrightTimeoutMillis());
     }
 
+    // Закриваємо браузерні ресурси та прибираємо створений тестом запис, якщо він залишився.
     @AfterEach
     void tearDown() {
         if (page != null && createdCourseName != null) {
             try {
+                // Якщо тест впав після створення запису, намагаємось прибрати тестові дані.
                 deleteScheduleRow(createdCourseName);
             } catch (Exception exception) {
                 // Preserve the original test failure; cleanup is best effort.
@@ -95,26 +104,32 @@ class ScheduleHappyPathE2ETests {
         if (browserContext != null) {
             browserContext.close();
         }
+
         if (browser != null) {
             browser.close();
         }
+
         if (playwright != null) {
             playwright.close();
         }
     }
 
+    // Happy-path сценарій: створюємо запис через UI, перевіряємо його появу і видаляємо назад через UI.
     @Test
     void scheduleHappyPathCreatesAndDeletesEntry() {
         runWithDiagnostics("schedule-happy-path-creates-and-deletes-entry", () -> {
+            // Генеруємо унікальні значення, щоб тест не конфліктував з уже наявними даними.
             String uniqueSuffix = String.valueOf(Instant.now().toEpochMilli());
             String uniqueCourseName = "E2E Course " + uniqueSuffix;
             String uniqueStudentName = "E2E Student " + uniqueSuffix;
             createdCourseName = uniqueCourseName;
 
+            // Переходимо на сторінку додавання і чекаємо, поки форма стане видимою.
             page.navigate(baseUrl + "/add");
             waitForAddPageForm();
             assertThat(page.locator("form").count()).isEqualTo(1);
 
+            // Заповнюємо форму тестовими даними.
             setInputValue("studentFirstName", uniqueStudentName);
             setInputValue("studentLastName", "Tester");
             setInputValue("teacherFirstName", "UI");
@@ -127,30 +142,36 @@ class ScheduleHappyPathE2ETests {
             setInputValue("startTime", "09:00:00");
             setInputValue("endTime", "10:30:00");
 
+            // Відправляємо форму і чекаємо повернення на головну сторінку зі списком розкладу.
             page.locator("button[type='submit']").click();
             page.waitForURL(baseUrl + "/");
             waitForSchedulePageHeader();
 
+            // Перевіряємо, що щойно створений рядок дійсно з'явився в таблиці.
             Locator createdRow = waitForRowContaining(uniqueCourseName,
                 "Created schedule row did not appear on the main page.");
             assertThat(createdRow.textContent())
                 .contains(uniqueStudentName)
                 .contains(uniqueCourseName);
 
+            // Видаляємо створений запис у межах самого happy-path сценарію.
             deleteScheduleRow(uniqueCourseName);
             createdCourseName = null;
         });
     }
 
+    // Видаляє рядок із таблиці за унікальною назвою курсу і перевіряє, що він зник із UI.
     private void deleteScheduleRow(String uniqueCourseName) {
         page.navigate(baseUrl + "/");
         waitForSchedulePageHeader();
 
+        // Якщо рядок уже зник, додаткових дій не потрібно.
         Locator rowToDelete = findRowContaining(uniqueCourseName);
         if (rowToDelete == null) {
             return;
         }
 
+        // Натискаємо кнопку видалення і чекаємо, поки рядок зникне з таблиці.
         rowToDelete.locator("button[type='submit']").click();
         page.waitForURL(baseUrl + "/");
         waitForSchedulePageHeader();
@@ -160,11 +181,13 @@ class ScheduleHappyPathE2ETests {
         assertThat(page.locator("body").textContent()).doesNotContain(uniqueCourseName);
     }
 
+    // Чекає появи рядка з потрібним текстом і повертає знайдений locator.
     private Locator waitForRowContaining(String text, String failureMessage) {
         waitFor(() -> findRowContaining(text) != null, failureMessage);
         return findRowContaining(text);
     }
 
+    // Шукає перший рядок таблиці, у тексті якого міститься потрібне значення.
     private Locator findRowContaining(String text) {
         Locator rows = page.locator("tbody tr");
         int count = rows.count();
@@ -178,10 +201,12 @@ class ScheduleHappyPathE2ETests {
         return null;
     }
 
+    // Заповнює input-поле за його HTML name-атрибутом.
     private void setInputValue(String fieldName, String value) {
         page.locator("[name='" + fieldName + "']").fill(value);
     }
 
+    // Чекає, поки на головній сторінці з'явиться заголовок розкладу.
     private void waitForSchedulePageHeader() {
         page.locator("h1")
             .filter(new Locator.FilterOptions().setHasText(SCHEDULE_PAGE_TITLE))
@@ -191,6 +216,7 @@ class ScheduleHappyPathE2ETests {
                 .setTimeout((double) pageReadyTimeoutMillis));
     }
 
+    // Чекає, поки сторінка додавання повністю відрендерить форму.
     private void waitForAddPageForm() {
         page.locator("form")
             .first()
@@ -199,6 +225,7 @@ class ScheduleHappyPathE2ETests {
                 .setTimeout((double) pageReadyTimeoutMillis));
     }
 
+    // Простий polling helper для умов, які не мають зручного вбудованого wait у Playwright.
     private void waitFor(BooleanSupplier condition, String failureMessage) {
         long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
         while (System.currentTimeMillis() < deadline) {
@@ -210,6 +237,7 @@ class ScheduleHappyPathE2ETests {
         throw new AssertionError(failureMessage);
     }
 
+    // Зчитує та нормалізує базовий URL застосунку з property або environment variable.
     private String resolveBaseUrl() {
         String configuredUrl = resolveOptionalValue(BASE_URL_PROPERTY, BASE_URL_ENV);
         if (configuredUrl == null || configuredUrl.isBlank()) {
@@ -219,6 +247,7 @@ class ScheduleHappyPathE2ETests {
         return normalizeBaseUrl(configuredUrl);
     }
 
+    // Прибирає зайвий "/" наприкінці та перевіряє, що URL абсолютний і коректний.
     private String normalizeBaseUrl(String configuredUrl) {
         String normalizedUrl = configuredUrl.endsWith("/")
             ? configuredUrl.substring(0, configuredUrl.length() - 1)
@@ -234,6 +263,7 @@ class ScheduleHappyPathE2ETests {
         return normalizedUrl;
     }
 
+    // Читає значення спочатку з JVM property, а якщо його нема — із змінної середовища.
     private String resolveOptionalValue(String propertyName, String envName) {
         String configuredValue = System.getProperty(propertyName);
         if (configuredValue == null || configuredValue.isBlank()) {
@@ -242,8 +272,10 @@ class ScheduleHappyPathE2ETests {
         return configuredValue;
     }
 
+    // Вибирає спосіб запуску браузера: через Selenium CDP у CI або локальний headless Chromium.
     private Browser createBrowser() {
         if (seleniumCdpUrl != null && !seleniumCdpUrl.isBlank()) {
+            // У CI підключаємось до вже запущеного Chromium у Selenium через CDP.
             return playwright.chromium().connectOverCDP(seleniumCdpUrl);
         }
 
@@ -252,6 +284,7 @@ class ScheduleHappyPathE2ETests {
             .setArgs(List.of("--disable-dev-shm-usage", "--no-sandbox")));
     }
 
+    // Визначає директорію для відео та screenshot, з урахуванням override через конфігурацію.
     private Path resolveArtifactsDir() {
         String configuredArtifactsDir = resolveOptionalValue(ARTIFACTS_DIR_PROPERTY, ARTIFACTS_DIR_ENV);
         if (configuredArtifactsDir == null || configuredArtifactsDir.isBlank()) {
@@ -260,21 +293,26 @@ class ScheduleHappyPathE2ETests {
         return Paths.get(configuredArtifactsDir).toAbsolutePath().normalize();
     }
 
+    // Обирає timeout готовності сторінки: кастомний, Render-специфічний або дефолтний.
     private int resolvePageReadyTimeoutMillis() {
         String configuredTimeout = resolveOptionalValue(
             PAGE_READY_TIMEOUT_MILLIS_PROPERTY,
             PAGE_READY_TIMEOUT_MILLIS_ENV
         );
+        
         if (configuredTimeout == null || configuredTimeout.isBlank()) {
+            // Render може запускати програму помітно довше, ніж локальне середовище.
             return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_PAGE_READY_TIMEOUT_MILLIS;
         }
         return Integer.parseInt(configuredTimeout);
     }
 
+    // Повертає базовий timeout Playwright для дій і навігації.
     private double resolvePlaywrightTimeoutMillis() {
         return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_TIMEOUT_MILLIS;
     }
 
+    // Перевіряє, чи тести зараз виконуються проти Render-host, де очікування довші.
     private boolean isRenderBaseUrl() {
         if (baseUrl == null || baseUrl.isBlank()) {
             return false;
@@ -285,6 +323,7 @@ class ScheduleHappyPathE2ETests {
         return host != null && host.endsWith(RENDER_HOST_SUFFIX);
     }
 
+    // Створює директорію артефактів і перетворює I/O помилки на зрозумілу помилку конфігурації тесту.
     private void createDirectory(Path directory) {
         try {
             Files.createDirectories(directory);
@@ -293,15 +332,18 @@ class ScheduleHappyPathE2ETests {
         }
     }
 
-    private void runWithDiagnostics(String testName, CheckedRunnable testBody) {
+    // Запускає тест так, щоб при будь-якому падінні спочатку зберегти screenshot сторінки.
+    private void runWithDiagnostics(String testName, Runnable testBody) {
         try {
             testBody.run();
         } catch (Throwable throwable) {
+            // Screenshot робимо до cleanup, щоб зберегти реальний стан сторінки в момент падіння.
             captureFailureScreenshot(testName);
             rethrowUnchecked(throwable);
         }
     }
 
+    // Зберігає full-page screenshot з унікальним ім'ям файлу в директорію артефактів.
     private void captureFailureScreenshot(String testName) {
         if (page == null) {
             return;
@@ -314,26 +356,28 @@ class ScheduleHappyPathE2ETests {
             .setType(ScreenshotType.PNG));
     }
 
+    // Формує ім'я файлу артефакту з назви тесту та timestamp.
     private String buildArtifactFileName(String testName, String extension) {
         return sanitizeFileName(testName) + "-" + Instant.now().toEpochMilli() + "." + extension;
     }
 
+    // Прибирає з імені файлу символи, які небажані для файлової системи.
     private String sanitizeFileName(String value) {
         return value.replaceAll("[^a-zA-Z0-9-_]+", "-");
     }
 
+    // Перекидає checked/unchecked помилки без втрати первинного типу RuntimeException або Error.
     private void rethrowUnchecked(Throwable throwable) {
         if (throwable instanceof RuntimeException) {
             throw (RuntimeException) throwable;
         }
+
         if (throwable instanceof Error) {
             throw (Error) throwable;
         }
+
         throw new IllegalStateException(throwable);
     }
 
-    @FunctionalInterface
-    private interface CheckedRunnable {
-        void run() throws Exception;
-    }
+    // Дозволяє передавати в helper-и lambda, які можуть викликати checked exception.
 }

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -112,6 +112,7 @@ class ScheduleHappyPathE2ETests {
             createdCourseName = uniqueCourseName;
 
             page.navigate(baseUrl + "/add");
+            waitForAddPageForm();
             assertThat(page.locator("form").count()).isEqualTo(1);
 
             setInputValue("studentFirstName", uniqueStudentName);
@@ -184,6 +185,14 @@ class ScheduleHappyPathE2ETests {
     private void waitForSchedulePageHeader() {
         page.locator("h1")
             .filter(new Locator.FilterOptions().setHasText(SCHEDULE_PAGE_TITLE))
+            .first()
+            .waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE)
+                .setTimeout((double) pageReadyTimeoutMillis));
+    }
+
+    private void waitForAddPageForm() {
+        page.locator("form")
             .first()
             .waitFor(new Locator.WaitForOptions()
                 .setState(WaitForSelectorState.VISIBLE)

--- a/workflows/scripts/run-e2e-test.sh
+++ b/workflows/scripts/run-e2e-test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare directories used by Maven logs and Playwright artifacts.
+mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
+
+# Wait until the Selenium service container is ready to accept sessions.
+for attempt in {1..30}; do
+  ready="$(curl --silent http://127.0.0.1:4444/status | jq -r '.value.ready // false')"
+  if [[ "$ready" == "true" ]]; then
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${ready:-false}" != "true" ]]; then
+  echo "Selenium Grid did not become ready in time." >&2
+  exit 1
+fi
+
+# Open a Selenium Chromium session and extract the CDP endpoint that Playwright will use.
+response="$(
+  curl --silent --show-error --fail-with-body \
+    --request POST \
+    --url http://127.0.0.1:4444/session \
+    --header "Content-Type: application/json" \
+    --data '{
+      "capabilities": {
+        "alwaysMatch": {
+          "browserName": "chrome",
+          "goog:chromeOptions": {
+            "args": ["--headless=new", "--disable-dev-shm-usage", "--no-sandbox"]
+          }
+        }
+      }
+    }'
+)"
+
+SESSION_ID="$(jq -r '.value.sessionId // empty' <<<"$response")"
+CDP_URL="$(jq -r '.value.capabilities["se:cdp"] // empty' <<<"$response")"
+
+if [[ -z "$SESSION_ID" || -z "$CDP_URL" ]]; then
+  echo "Unable to resolve Selenium session metadata." >&2
+  echo "$response" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [[ -n "${SESSION_ID:-}" ]]; then
+    curl --silent --show-error --fail-with-body \
+      --request DELETE \
+      --url "http://127.0.0.1:4444/session/${SESSION_ID}" >/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+# Rewrite the Selenium-reported CDP URL to the runner-visible localhost endpoint.
+CDP_PATH="${CDP_URL#ws://*/}"
+export E2E_SELENIUM_CDP_URL="ws://127.0.0.1:4444/${CDP_PATH}"
+export E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-target/e2e-artifacts}"
+
+set -o pipefail
+mvn -B -P e2e-ui -Dcheckstyle.skip=true -DskipUnitTests=true -DskipIntegrationTests=true verify \
+  | tee target/ci-logs/e2e-ui-tests.log

--- a/workflows/scripts/run-e2e-test.sh
+++ b/workflows/scripts/run-e2e-test.sh
@@ -3,45 +3,89 @@ set -euo pipefail
 
 # Prepare directories used by Maven logs and Playwright artifacts.
 mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
+LOG_FILE="target/ci-logs/e2e-ui-tests.log"
+
+log() {
+  echo "$1" | tee -a "$LOG_FILE"
+}
+
+: > "$LOG_FILE"
 
 # Wait until the Selenium service container is ready to accept sessions.
 for attempt in {1..30}; do
-  ready="$(curl --silent http://127.0.0.1:4444/status | jq -r '.value.ready // false')"
+  ready_response="$(
+    curl --silent --show-error http://127.0.0.1:4444/status
+  )" || ready_response=""
+
+  if [[ -n "$ready_response" ]]; then
+    ready="$(jq -r '.value.ready // false' <<<"$ready_response" 2>/dev/null)" || ready="false"
+  else
+    ready="false"
+  fi
+
   if [[ "$ready" == "true" ]]; then
+    log "Selenium Grid reported ready on attempt ${attempt}."
     break
   fi
+
+  log "Selenium Grid not ready on attempt ${attempt}."
   sleep 2
 done
 
 if [[ "${ready:-false}" != "true" ]]; then
-  echo "Selenium Grid did not become ready in time." >&2
+  log "Selenium Grid did not become ready in time."
   exit 1
 fi
 
 # Open a Selenium Chromium session and extract the CDP endpoint that Playwright will use.
-response="$(
-  curl --silent --show-error --fail-with-body \
-    --request POST \
-    --url http://127.0.0.1:4444/session \
-    --header "Content-Type: application/json" \
-    --data '{
-      "capabilities": {
-        "alwaysMatch": {
-          "browserName": "chrome",
-          "goog:chromeOptions": {
-            "args": ["--headless=new", "--disable-dev-shm-usage", "--no-sandbox"]
+SESSION_ID=""
+CDP_URL=""
+
+for attempt in {1..15}; do
+  tmp_response_file="$(mktemp)"
+  http_code="$(
+    curl --silent --show-error \
+      --output "$tmp_response_file" \
+      --write-out "%{http_code}" \
+      --request POST \
+      --url http://127.0.0.1:4444/session \
+      --header "Content-Type: application/json" \
+      --data '{
+        "capabilities": {
+          "alwaysMatch": {
+            "browserName": "chrome",
+            "goog:chromeOptions": {
+              "args": ["--headless=new", "--disable-dev-shm-usage", "--no-sandbox"]
+            }
           }
         }
-      }
-    }'
-)"
+      }'
+  )" || http_code="curl_failed"
 
-SESSION_ID="$(jq -r '.value.sessionId // empty' <<<"$response")"
-CDP_URL="$(jq -r '.value.capabilities["se:cdp"] // empty' <<<"$response")"
+  response="$(cat "$tmp_response_file")"
+  rm -f "$tmp_response_file"
+
+  if [[ "$http_code" == "200" ]]; then
+    SESSION_ID="$(jq -r '.value.sessionId // empty' <<<"$response")"
+    CDP_URL="$(jq -r '.value.capabilities["se:cdp"] // empty' <<<"$response")"
+    if [[ -n "$SESSION_ID" && -n "$CDP_URL" ]]; then
+      log "Created Selenium session on attempt ${attempt}."
+      break
+    fi
+    log "Selenium session response on attempt ${attempt} did not contain session metadata."
+    log "$response"
+  else
+    log "Selenium session creation attempt ${attempt} failed with status ${http_code}."
+    if [[ -n "$response" ]]; then
+      log "$response"
+    fi
+  fi
+
+  sleep 2
+done
 
 if [[ -z "$SESSION_ID" || -z "$CDP_URL" ]]; then
-  echo "Unable to resolve Selenium session metadata." >&2
-  echo "$response" >&2
+  log "Unable to resolve Selenium session metadata after retries."
   exit 1
 fi
 
@@ -60,6 +104,9 @@ CDP_PATH="${CDP_URL#ws://*/}"
 export E2E_SELENIUM_CDP_URL="ws://127.0.0.1:4444/${CDP_PATH}"
 export E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-target/e2e-artifacts}"
 
+log "Resolved Playwright CDP endpoint: ${E2E_SELENIUM_CDP_URL}"
+log "Starting Maven E2E UI test run."
+
 set -o pipefail
 mvn -B -P e2e-ui -Dcheckstyle.skip=true -DskipUnitTests=true -DskipIntegrationTests=true verify \
-  | tee target/ci-logs/e2e-ui-tests.log
+  | tee -a "$LOG_FILE"

--- a/workflows/scripts/run-e2e-test.sh
+++ b/workflows/scripts/run-e2e-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Prepare directories used by Maven logs and Playwright artifacts.
+# Готуємо директорії для логів Maven і артефактів Playwright.
 mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
 LOG_FILE="target/ci-logs/e2e-ui-tests.log"
 
@@ -9,10 +9,12 @@ log() {
   echo "$1" | tee -a "$LOG_FILE"
 }
 
+# Очищаємо лог на початку кожного прогону, щоб артефакт містив лише актуальний запуск.
 : > "$LOG_FILE"
 
-# Wait until the Selenium service container is ready to accept sessions.
+# Чекаємо, поки Selenium почне стабільно відповідати на /status після старту контейнера.
 for attempt in {1..90}; do
+  # Читаємо статус Grid з окремими timeout, щоб короткі мережеві збої не валили весь скрипт.
   ready_response="$(
     curl --silent --show-error \
       --connect-timeout 2 \
@@ -20,31 +22,36 @@ for attempt in {1..90}; do
       http://127.0.0.1:4444/status
   )" || ready_response=""
 
+  # Якщо відповідь є, намагаємось витягнути прапорець готовності з JSON.
   if [[ -n "$ready_response" ]]; then
     ready="$(jq -r '.value.ready // false' <<<"$ready_response" 2>/dev/null)" || ready="false"
   else
     ready="false"
   fi
 
+  # Коли Grid готовий, можна переходити до створення браузерної сесії.
   if [[ "$ready" == "true" ]]; then
     log "Selenium Grid reported ready on attempt ${attempt}."
     break
   fi
 
+  # Логуємо повторну спробу, щоб у CI було видно, чи є повільний старт Selenium.
   log "Selenium Grid not ready on attempt ${attempt}."
   sleep 2
 done
 
+# Якщо навіть після всіх спроб Selenium не готовий, завершуємо прогін явною помилкою.
 if [[ "${ready:-false}" != "true" ]]; then
   log "Selenium Grid did not become ready in time."
   exit 1
 fi
 
-# Open a Selenium Chromium session and extract the CDP endpoint that Playwright will use.
+# Відкриваємо Selenium session і дістаємо CDP endpoint для Playwright.
 SESSION_ID=""
 CDP_URL=""
 
 for attempt in {1..30}; do
+  # Тимчасовий файл потрібен, щоб окремо зчитати тіло відповіді і HTTP-код від curl.
   tmp_response_file="$(mktemp)"
   http_code="$(
     curl --silent --show-error \
@@ -67,28 +74,34 @@ for attempt in {1..30}; do
       }'
   )" || http_code="curl_failed"
 
+  # Читаємо JSON відповіді незалежно від того, успішний це статус чи ні.
   response="$(cat "$tmp_response_file")"
   rm -f "$tmp_response_file"
 
   if [[ "$http_code" == "200" ]]; then
+    # Для успішної відповіді витягуємо id Selenium session і CDP URL браузера.
     SESSION_ID="$(jq -r '.value.sessionId // empty' <<<"$response")"
     CDP_URL="$(jq -r '.value.capabilities["se:cdp"] // empty' <<<"$response")"
     if [[ -n "$SESSION_ID" && -n "$CDP_URL" ]]; then
       log "Created Selenium session on attempt ${attempt}."
       break
     fi
+    # Іноді Selenium відповідає 200, але ще не повертає повні capabilities; це теж повторюємо.
     log "Selenium session response on attempt ${attempt} did not contain session metadata."
     log "$response"
   else
+    # Для неуспішного статусу залишаємо в логах HTTP-код і відповідь сервера.
     log "Selenium session creation attempt ${attempt} failed with status ${http_code}."
     if [[ -n "$response" ]]; then
       log "$response"
     fi
   fi
 
+  # Даємо Selenium короткий час на стабілізацію перед наступною спробою.
   sleep 2
 done
 
+# Якщо не вдалося отримати session id або CDP URL, далі запускати Playwright немає сенсу.
 if [[ -z "$SESSION_ID" || -z "$CDP_URL" ]]; then
   log "Unable to resolve Selenium session metadata after retries."
   exit 1
@@ -96,6 +109,7 @@ fi
 
 cleanup() {
   if [[ -n "${SESSION_ID:-}" ]]; then
+    # Закриваємо Selenium session навіть після падіння Maven, щоб не залишати "висячі" браузери.
     curl --silent --show-error --fail-with-body \
       --request DELETE \
       --url "http://127.0.0.1:4444/session/${SESSION_ID}" >/dev/null || true
@@ -104,14 +118,16 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Rewrite the Selenium-reported CDP URL to the runner-visible localhost endpoint.
+# Selenium повертає внутрішню адресу контейнера, тому переписуємо її на localhost runner-а.
 CDP_PATH="${CDP_URL#ws://*/}"
 export E2E_SELENIUM_CDP_URL="ws://127.0.0.1:4444/${CDP_PATH}"
 export E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-target/e2e-artifacts}"
 
+# Логуємо ключові параметри перед стартом Maven, щоб легше діагностувати CI-запуск.
 log "Resolved Playwright CDP endpoint: ${E2E_SELENIUM_CDP_URL}"
 log "Starting Maven E2E UI test run."
 
+# Запускаємо Maven-профіль E2E UI і одночасно пишемо консольний вивід у CI-лог.
 set -o pipefail
 mvn -B -P e2e-ui -Dcheckstyle.skip=true -DskipUnitTests=true -DskipIntegrationTests=true verify \
   | tee -a "$LOG_FILE"

--- a/workflows/scripts/run-e2e-test.sh
+++ b/workflows/scripts/run-e2e-test.sh
@@ -12,9 +12,12 @@ log() {
 : > "$LOG_FILE"
 
 # Wait until the Selenium service container is ready to accept sessions.
-for attempt in {1..30}; do
+for attempt in {1..90}; do
   ready_response="$(
-    curl --silent --show-error http://127.0.0.1:4444/status
+    curl --silent --show-error \
+      --connect-timeout 2 \
+      --max-time 10 \
+      http://127.0.0.1:4444/status
   )" || ready_response=""
 
   if [[ -n "$ready_response" ]]; then
@@ -41,10 +44,12 @@ fi
 SESSION_ID=""
 CDP_URL=""
 
-for attempt in {1..15}; do
+for attempt in {1..30}; do
   tmp_response_file="$(mktemp)"
   http_code="$(
     curl --silent --show-error \
+      --connect-timeout 2 \
+      --max-time 15 \
       --output "$tmp_response_file" \
       --write-out "%{http_code}" \
       --request POST \


### PR DESCRIPTION
### What does this PR do?
- adds a Playwright for Java happy-path E2E test suite in ScheduleHappyPathE2ETests
- runs the E2E test against a real deployed application URL provided through e2e.base-url / E2E_BASE_URL
- records E2E videos and captures screenshots on failure into target/e2e-artifacts
- adds a dedicated Maven e2e-ui profile and Playwright dependency for *E2ETests.java
- adds a reusable run-e2e-test GitHub Actions workflow that runs the tests
- updates the Render deploy workflow to return the deployed application_url and wires CI to run E2E tests after successful PR deploys
- updates the README with the current local E2E command and the actual CI/E2E workflow flow

### Related issue
#9

### Description for the changelog
```
Add Playwright-based happy-path E2E UI tests and CI wiring to run them against the deployed Render application.
```