### PR TITLE
Fix name of run-e2e-test GitHub Action

### DIFF
--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -1,4 +1,4 @@
-name: run-e2e-test
+name: E2E UI Tests Run
 
 on:
   # Дозволяє викликати workflow з інших workflow, передаючи URL уже розгорнутого застосунку.


### PR DESCRIPTION
### What does this PR do?
Set name of run-e2e-test GitHub Action to "E2E UI Tests Run".

### Related issue
#9 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```