### PR TITLE
Improve E2E UI test startup timeout handling and diagnostics

### DIFF
--- a/.github/workflows/scripts/run-e2e-test.sh
+++ b/.github/workflows/scripts/run-e2e-test.sh
@@ -122,9 +122,11 @@ trap cleanup EXIT
 CDP_PATH="${CDP_URL#ws://*/}"
 export E2E_SELENIUM_CDP_URL="ws://127.0.0.1:4444/${CDP_PATH}"
 export E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-target/e2e-artifacts}"
+export DEBUG="pw:api,pw:browser"
 
 # Логуємо ключові параметри перед стартом Maven, щоб легше діагностувати CI-запуск.
 log "Resolved Playwright CDP endpoint: ${E2E_SELENIUM_CDP_URL}"
+log "Enabled Playwright debug namespaces: ${DEBUG}"
 log "Starting Maven E2E UI test run."
 
 # Запускаємо Maven-профіль E2E UI і одночасно пишемо консольний вивід у CI-лог.

--- a/README.md
+++ b/README.md
@@ -321,10 +321,13 @@ Audit done.
 `mvn test`
 2. Тільки integration-тести:
 `mvn -DskipUnitTests=true verify`
-3. Тільки E2E UI-тести проти вже розгорнутого середовища:
-`mvn -B -P e2e-ui '-Dcheckstyle.skip=true' '-DskipUnitTests=true' '-DskipIntegrationTests=true' '-De2e.base-url=https://your-app.onrender.com' verify`
+3. Тільки E2E UI-тести проти вже розгорнутого середовища за адресою https://your-app.onrender.com:
+```
+set DEBUG=pw:api,pw:browser
+mvn -B -P e2e-ui "-Dcheckstyle.skip=true" "-DskipUnitTests=true" "-DskipIntegrationTests=true" "-De2e.base-url=https://your-app.onrender.com" clean verify
+```
 4. Повна перевірка:
-`mvn verify`
+`mvn clean verify`
 
 Звіти:
 1. Unit test reports: `target/surefire-reports/`

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -36,7 +36,7 @@ class ScheduleHappyPathE2ETests {
     private static final String SCHEDULE_PAGE_TITLE = "Розклад коледжу";
     private static final String RENDER_HOST_SUFFIX = ".onrender.com";
     private static final int WAIT_TIMEOUT_MILLIS = 15000;
-    private static final int POLL_INTERVAL_MILLIS = 250;
+    private static final int POLL_INTERVAL_MILLIS = 1200;
     private static final int DEFAULT_PAGE_READY_TIMEOUT_MILLIS = 180000;
     private static final int DEFAULT_TIMEOUT_MILLIS = 30000;
     private static final int RENDER_TIMEOUT_MILLIS = 180000;
@@ -84,7 +84,7 @@ class ScheduleHappyPathE2ETests {
             .setViewportSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT));
         page = browserContext.newPage();
         page.setDefaultTimeout(resolvePlaywrightTimeoutMillis());
-        page.setDefaultNavigationTimeout(resolvePlaywrightTimeoutMillis());
+        page.setDefaultNavigationTimeout(pageReadyTimeoutMillis);
     }
 
     // Закриваємо браузерні ресурси та прибираємо створений тестом запис, якщо він залишився.
@@ -125,7 +125,7 @@ class ScheduleHappyPathE2ETests {
             createdCourseName = uniqueCourseName;
 
             // Переходимо на сторінку додавання і чекаємо, поки форма стане видимою.
-            page.navigate(baseUrl + "/add");
+            navigateTo(baseUrl + "/add");
             waitForAddPageForm();
             assertThat(page.locator("form").count()).isEqualTo(1);
 
@@ -162,7 +162,7 @@ class ScheduleHappyPathE2ETests {
 
     // Видаляє рядок із таблиці за унікальною назвою курсу і перевіряє, що він зник із UI.
     private void deleteScheduleRow(String uniqueCourseName) {
-        page.navigate(baseUrl + "/");
+        navigateTo(baseUrl + "/");
         waitForSchedulePageHeader();
 
         // Якщо рядок уже зник, додаткових дій не потрібно.
@@ -235,6 +235,26 @@ class ScheduleHappyPathE2ETests {
             page.waitForTimeout(POLL_INTERVAL_MILLIS);
         }
         throw new AssertionError(failureMessage);
+    }
+
+    // Якщо застосунок ще не доступний, повторює навігацію в межах уже налаштованого readiness timeout.
+    private void navigateTo(String url) {
+        long deadline = System.currentTimeMillis() + pageReadyTimeoutMillis;
+        RuntimeException lastFailure = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                page.navigate(url);
+                return;
+            } catch (RuntimeException exception) {
+                lastFailure = exception;
+                page.waitForTimeout(POLL_INTERVAL_MILLIS);
+            }
+        }
+        throw new AssertionError(
+            "Application at " + url + " did not become available within "
+                + pageReadyTimeoutMillis + " ms.",
+            lastFailure
+        );
     }
 
     // Зчитує та нормалізує базовий URL застосунку з property або environment variable.


### PR DESCRIPTION
### What does this PR do?
Improves E2E UI test diagnostics and startup handling for deployed environments. The branch updates `ScheduleHappyPathE2ETests` to retry initial navigation until the configured page-ready timeout expires, aligns Playwright navigation timeout with the page-ready timeout, and documents/enables Playwright debug logging for E2E runs.

### Related issue
#9

### Description for the changelog
```markdown changelog
Improve E2E UI test startup retries and add Playwright debug logging for deployed runs.
```