### PR TITLE
Make it possible to edit schedule item in Web UI

### DIFF
--- a/src/main/java/com/college/ScheduleController.java
+++ b/src/main/java/com/college/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.college;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,9 +34,43 @@ public class ScheduleController {
         return "add";
     }
 
+    @GetMapping("/edit/{id}")
+    public String showEditForm(@PathVariable String id, Model model) {
+        Optional<Schedule> schedule = scheduleRepository.findById(id);
+        if (schedule.isEmpty()) {
+            return "redirect:/";
+        }
+
+        model.addAttribute("schedule", schedule.get());
+        return "edit";
+    }
+
     @PostMapping("/add")
     public String addSchedule(@ModelAttribute Schedule schedule) {
         scheduleRepository.save(schedule);
+        return "redirect:/";
+    }
+
+    @PostMapping("/edit/{id}")
+    public String editSchedule(@PathVariable String id, @ModelAttribute Schedule schedule) {
+        Optional<Schedule> existingSchedule = scheduleRepository.findById(id);
+        if (existingSchedule.isEmpty()) {
+            return "redirect:/";
+        }
+
+        Schedule scheduleToUpdate = existingSchedule.get();
+        scheduleToUpdate.setStudentFirstName(schedule.getStudentFirstName());
+        scheduleToUpdate.setStudentLastName(schedule.getStudentLastName());
+        scheduleToUpdate.setTeacherFirstName(schedule.getTeacherFirstName());
+        scheduleToUpdate.setTeacherLastName(schedule.getTeacherLastName());
+        scheduleToUpdate.setCourseName(schedule.getCourseName());
+        scheduleToUpdate.setDepartmentName(schedule.getDepartmentName());
+        scheduleToUpdate.setRoomNumber(schedule.getRoomNumber());
+        scheduleToUpdate.setSemester(schedule.getSemester());
+        scheduleToUpdate.setYear(schedule.getYear());
+        scheduleToUpdate.setStartTime(schedule.getStartTime());
+        scheduleToUpdate.setEndTime(schedule.getEndTime());
+        scheduleRepository.save(scheduleToUpdate);
         return "redirect:/";
     }
 

--- a/src/main/resources/templates/edit.html
+++ b/src/main/resources/templates/edit.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Редагувати заняття</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="container mt-4">
+    <h1>Редагувати заняття</h1>
+    <form th:action="@{/edit/{id}(id=${schedule.id})}" th:object="${schedule}" method="post" class="col-md-6">
+        <div class="mb-3">
+            <label class="form-label">Ім'я студента</label>
+            <input type="text" class="form-control" th:field="*{studentFirstName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Прізвище студента</label>
+            <input type="text" class="form-control" th:field="*{studentLastName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Ім'я викладача</label>
+            <input type="text" class="form-control" th:field="*{teacherFirstName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Прізвище викладача</label>
+            <input type="text" class="form-control" th:field="*{teacherLastName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Назва курсу</label>
+            <input type="text" class="form-control" th:field="*{courseName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Кафедра</label>
+            <input type="text" class="form-control" th:field="*{departmentName}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Номер аудиторії</label>
+            <input type="text" class="form-control" th:field="*{roomNumber}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Семестр</label>
+            <input type="text" class="form-control" th:field="*{semester}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Рік</label>
+            <input type="text" class="form-control" th:field="*{year}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Початок заняття</label>
+            <input type="text" class="form-control" th:field="*{startTime}"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Закінчення заняття</label>
+            <input type="text" class="form-control" th:field="*{endTime}"/>
+        </div>
+        <button type="submit" class="btn btn-primary">Зберегти зміни</button>
+        <a th:href="@{/}" class="btn btn-secondary ms-2">Повернутись до розкладу</a>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/schedule.html
+++ b/src/main/resources/templates/schedule.html
@@ -39,9 +39,12 @@
                 <td th:text="${schedule.startTime}"></td>
                 <td th:text="${schedule.endTime}"></td>
                 <td>
-                    <form th:action="@{/delete/{id}(id=${schedule.id})}" method="post">
-                        <button type="submit" class="btn btn-danger btn-sm">Видалити</button>
-                    </form>
+                    <div class="d-flex gap-2">
+                        <a th:href="@{/edit/{id}(id=${schedule.id})}" class="btn btn-primary btn-sm">Редагувати</a>
+                        <form th:action="@{/delete/{id}(id=${schedule.id})}" method="post">
+                            <button type="submit" class="btn btn-danger btn-sm">Видалити</button>
+                        </form>
+                    </div>
                 </td>
             </tr>
         </tbody>

--- a/src/test/java/com/college/ScheduleControllerTest.java
+++ b/src/test/java/com/college/ScheduleControllerTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 
@@ -66,6 +68,33 @@ class ScheduleControllerTest {
     }
 
     @Test
+    void showEditFormReturnsEditViewNameForExistingSchedule() {
+        ScheduleRepository repository = mock(ScheduleRepository.class);
+        Schedule schedule = aSchedule().build();
+        ReflectionTestUtils.setField(schedule, "id", "id-123");
+        when(repository.findById("id-123")).thenReturn(Optional.of(schedule));
+        ScheduleController controller = new ScheduleController(repository);
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.showEditForm("id-123", model);
+
+        assertEquals("edit", viewName);
+        assertEquals(schedule, model.getAttribute("schedule"));
+    }
+
+    @Test
+    void showEditFormRedirectsWhenScheduleIsMissing() {
+        ScheduleRepository repository = mock(ScheduleRepository.class);
+        when(repository.findById("missing-id")).thenReturn(Optional.empty());
+        ScheduleController controller = new ScheduleController(repository);
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.showEditForm("missing-id", model);
+
+        assertEquals("redirect:/", viewName);
+    }
+
+    @Test
     void addScheduleSavesToRepositoryAndRedirects() {
         ScheduleRepository repository = mock(ScheduleRepository.class);
         ScheduleController controller = new ScheduleController(repository);
@@ -74,6 +103,37 @@ class ScheduleControllerTest {
         String viewName = controller.addSchedule(schedule);
 
         verify(repository, times(1)).save(schedule);
+        assertEquals("redirect:/", viewName);
+    }
+
+    @Test
+    void editScheduleUpdatesExistingRecordAndRedirects() {
+        ScheduleRepository repository = mock(ScheduleRepository.class);
+        Schedule persistedSchedule = aSchedule().build();
+        ReflectionTestUtils.setField(persistedSchedule, "id", "id-123");
+        when(repository.findById("id-123")).thenReturn(Optional.of(persistedSchedule));
+        ScheduleController controller = new ScheduleController(repository);
+        Schedule editedSchedule = aSchedule()
+            .withStudentFirstName("Оновлена Аліса")
+            .withCourseName("Тестування ПЗ")
+            .build();
+
+        String viewName = controller.editSchedule("id-123", editedSchedule);
+
+        verify(repository, times(1)).save(persistedSchedule);
+        assertEquals("Оновлена Аліса", persistedSchedule.getStudentFirstName());
+        assertEquals("Тестування ПЗ", persistedSchedule.getCourseName());
+        assertEquals("redirect:/", viewName);
+    }
+
+    @Test
+    void editScheduleRedirectsWhenScheduleIsMissing() {
+        ScheduleRepository repository = mock(ScheduleRepository.class);
+        when(repository.findById("missing-id")).thenReturn(Optional.empty());
+        ScheduleController controller = new ScheduleController(repository);
+
+        String viewName = controller.editSchedule("missing-id", aSchedule().build());
+
         assertEquals("redirect:/", viewName);
     }
 

--- a/src/test/java/com/college/ScheduleFlowIntegrationTests.java
+++ b/src/test/java/com/college/ScheduleFlowIntegrationTests.java
@@ -101,6 +101,94 @@ class ScheduleFlowIntegrationTests {
     }
 
     @Test
+    void editPageRendersFormWithExistingScheduleModel() throws Exception {
+        Schedule saved = scheduleRepository.save(new Schedule(
+            "Аліса",
+            "Мельник",
+            "Іван",
+            "Петренко",
+            "Вступ до програмування",
+            "Комп`ютерні науки",
+            "210",
+            "Осінь",
+            "2024",
+            "09:00:00",
+            "10:30:00"
+        ));
+
+        mockMvc.perform(get("/edit/{id}", saved.getId()))
+            .andExpect(status().isOk())
+            .andExpect(view().name("edit"))
+            .andExpect(model().attributeExists("schedule"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Вступ до програмування")));
+    }
+
+    @Test
+    void editPageRedirectsToMainPageWhenScheduleIsMissing() throws Exception {
+        mockMvc.perform(get("/edit/{id}", "missing-id"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+    }
+
+    @Test
+    void editEndpointUpdatesPersistedScheduleInMongo() throws Exception {
+        Schedule saved = scheduleRepository.save(new Schedule(
+            "Аліса",
+            "Мельник",
+            "Іван",
+            "Петренко",
+            "Вступ до програмування",
+            "Комп`ютерні науки",
+            "210",
+            "Осінь",
+            "2024",
+            "09:00:00",
+            "10:30:00"
+        ));
+
+        mockMvc.perform(post("/edit/{id}", saved.getId())
+                .param("studentFirstName", "Оновлена Аліса")
+                .param("studentLastName", "Мельник")
+                .param("teacherFirstName", "Іван")
+                .param("teacherLastName", "Петренко")
+                .param("courseName", "Тестування ПЗ")
+                .param("departmentName", "QA")
+                .param("roomNumber", "305")
+                .param("semester", "Весна")
+                .param("year", "2026")
+                .param("startTime", "11:00:00")
+                .param("endTime", "12:30:00"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+
+        Schedule updated = scheduleRepository.findById(saved.getId()).orElseThrow();
+        assertThat(updated.getStudentFirstName()).isEqualTo("Оновлена Аліса");
+        assertThat(updated.getCourseName()).isEqualTo("Тестування ПЗ");
+        assertThat(updated.getDepartmentName()).isEqualTo("QA");
+        assertThat(updated.getRoomNumber()).isEqualTo("305");
+    }
+
+    @Test
+    void editEndpointRedirectsToMainPageWhenScheduleIsMissing() throws Exception {
+        mockMvc.perform(post("/edit/{id}", "missing-id")
+                .param("studentFirstName", "Оновлена Аліса")
+                .param("studentLastName", "Мельник")
+                .param("teacherFirstName", "Іван")
+                .param("teacherLastName", "Петренко")
+                .param("courseName", "Тестування ПЗ")
+                .param("departmentName", "QA")
+                .param("roomNumber", "305")
+                .param("semester", "Весна")
+                .param("year", "2026")
+                .param("startTime", "11:00:00")
+                .param("endTime", "12:30:00"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+
+        assertThat(scheduleRepository.findAll()).isEmpty();
+    }
+
+    @Test
     void deleteEndpointRemovesPersistedScheduleFromMongo() throws Exception {
         Schedule saved = scheduleRepository.save(new Schedule(
             "Аліса",

--- a/src/test/java/com/college/ScheduleHappyPathE2ETests.java
+++ b/src/test/java/com/college/ScheduleHappyPathE2ETests.java
@@ -122,6 +122,8 @@ class ScheduleHappyPathE2ETests {
             String uniqueSuffix = String.valueOf(Instant.now().toEpochMilli());
             String uniqueCourseName = "E2E Course " + uniqueSuffix;
             String uniqueStudentName = "E2E Student " + uniqueSuffix;
+            String updatedCourseName = uniqueCourseName + " Updated";
+            String updatedStudentName = uniqueStudentName + " Updated";
             createdCourseName = uniqueCourseName;
 
             // Переходимо на сторінку додавання і чекаємо, поки форма стане видимою.
@@ -155,7 +157,22 @@ class ScheduleHappyPathE2ETests {
                 .contains(uniqueCourseName);
 
             // Видаляємо створений запис у межах самого happy-path сценарію.
-            deleteScheduleRow(uniqueCourseName);
+            createdRow.locator("a").filter(new Locator.FilterOptions().setHasText("Редагувати")).click();
+            waitForAddPageForm();
+            setInputValue("studentFirstName", updatedStudentName);
+            setInputValue("courseName", updatedCourseName);
+            page.locator("button[type='submit']").click();
+            page.waitForURL(baseUrl + "/");
+            waitForSchedulePageHeader();
+
+            Locator updatedRow = waitForRowContaining(updatedCourseName,
+                "Updated schedule row did not appear on the main page.");
+            assertThat(updatedRow.textContent())
+                .contains(updatedStudentName)
+                .contains(updatedCourseName);
+
+            createdCourseName = updatedCourseName;
+            deleteScheduleRow(updatedCourseName);
             createdCourseName = null;
         });
     }


### PR DESCRIPTION
### What does this PR do?
Adds end-to-end editing support for schedule entries in the web application. This includes a new `/edit/{id}` form flow, an update endpoint in `ScheduleController`, an Edit button in the main schedule table, and expanded unit, integration, and E2E test coverage for editing existing records and handling missing IDs.

### Related issue


### Description for the changelog
```markdown changelog
Add Web UI support for editing schedule entries with unit, integration, and E2E test coverage.
```